### PR TITLE
[Hotfix] Disable Country Code

### DIFF
--- a/simplq/src/components/Layout.jsx
+++ b/simplq/src/components/Layout.jsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const handleClick = (props) => {
-  props.history.push('/');
+  window.location = '/';
 };
 
 function Layout(props) {
@@ -54,4 +54,4 @@ function Layout(props) {
   );
 }
 
-export default withRouter(Layout);
+export default Layout;

--- a/simplq/src/components/page/JoinQueue/Form.jsx
+++ b/simplq/src/components/page/JoinQueue/Form.jsx
@@ -72,6 +72,7 @@ export function JoinQueueForm(props) {
         helperText={invalidName ? 'Name is required' : ''}
       />
       <PhoneInput
+        disableCountryCode
         containerClass={classes.textField}
         placeholder="Phone Number"
         country={'in'}


### PR DESCRIPTION
@raima-zachariah was testing, and she noticed that the country code is coming, but '+' is not there in the number send back to the backend. This was giving issue as the user will type 9400329950 and we store 919400329950.

Since the `+` was not there, the number, it says doesn't exist. Could not blindly append a '+' because if the user removed the `+91` that is pre-filled, and types in the number, say with a 0, like 09400329950, then it will lead to storing +09400329950 which is also not correct.

Hence I disabled the entire country code for now.