### PR TITLE
Fix Button Not Clickable on Larger Screens

### DIFF
--- a/simplq/src/styles/homePage.module.scss
+++ b/simplq/src/styles/homePage.module.scss
@@ -16,6 +16,8 @@ div {
   .create-join-form {
     margin: auto; // centering
     max-width: 35rem;
+    position: relative;
+    z-index: 3;
     .button-group {
       @include center-horizontally();
       button {
@@ -29,6 +31,7 @@ div {
     bottom: 0;
     position: absolute;
     display: flex;
+    z-index: 2;
   }
 }
 


### PR DESCRIPTION
The buttons where going under the svg. Giving the `create-join-form` a higher `z-index` fixes this.

https://www.freecodecamp.org/news/4-reasons-your-z-index-isnt-working-and-how-to-fix-it-coder-coder-6bc05f103e6c/