### PR TITLE
Add Overlay to Navbar in Mobile/Tablet View

### DIFF
--- a/simplq/src/components/pages/Home/Nav/Burger.jsx
+++ b/simplq/src/components/pages/Home/Nav/Burger.jsx
@@ -7,6 +7,7 @@ const Burger = () => {
 
   return (
     <>
+      <div className={styles['left-nav-overlay']} open={open} onClick={() => setOpen(!open)}></div>
       <div className={styles['burger']} open={open} onClick={() => setOpen(!open)}>
         <div open={open} onClick={() => setOpen(!open)} />
         <div open={open} onClick={() => setOpen(!open)} />

--- a/simplq/src/styles/homePage.module.scss
+++ b/simplq/src/styles/homePage.module.scss
@@ -233,6 +233,21 @@
   }
 }
 
+.left-nav-overlay {
+  display: none;
+  @media (max-width: 768px) {
+    &[open] {
+      display: block;
+      height: 100vh;
+      width: 100vw;
+      position: fixed;
+      top: 0;
+      left: 0;
+      background: rgba(0, 0, 0, 0.5);
+    }
+  }
+}
+
 .navbar {
   width: 100%;
   height: 4rem;


### PR DESCRIPTION
Fix for Issue #276 
Added a dark tint overlay container in the mobile/tablet view. On clicking the overlay container navbar will close.