### PR TITLE
Switch to Queue Name Instead of QueueId in Urls

### DIFF
--- a/simplq/src/components/Routes.jsx
+++ b/simplq/src/components/Routes.jsx
@@ -14,7 +14,7 @@ export default () => {
         <Switch>
           <Route path="/" exact component={Home} />
           <Route path="/queue/:queueId" exact component={AdminQueue} />
-          <Route path="/j/:queueId" exact component={JoinQueueWithDetails} />
+          <Route path="/j/:queueName" exact component={JoinQueueWithDetails} />
           <Route path="/token/:tokenId" exact component={QueueStatus} />
           <Route component={PageNotFound} />
         </Switch>

--- a/simplq/src/components/pages/Admin/ShareQueue.jsx
+++ b/simplq/src/components/pages/Admin/ShareQueue.jsx
@@ -3,9 +3,9 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 import { ShareButton } from '../../common/Button/Button.stories';
 
-const CopyQueue = (props) => {
+const ShareQueue = (props) => {
   const [clicked, setClicked] = React.useState(false);
-  const shareUrl = `${window.location.origin}/j/${props.queueId}`;
+  const shareUrl = `${window.location.origin}/j/${props.queueName}`;
 
   const handleShareButtonClick = () => {
     setClicked(true);
@@ -34,4 +34,4 @@ const CopyQueue = (props) => {
   );
 };
 
-export default CopyQueue;
+export default ShareQueue;

--- a/simplq/src/components/pages/Admin/index.jsx
+++ b/simplq/src/components/pages/Admin/index.jsx
@@ -70,7 +70,7 @@ export default (props) => {
           <RefreshButton onClick={update} />
         </div>
         <div className={styles['admin-button']}>
-          <ShareQueue queueId={queueId} className={styles.shareButton} />
+          <ShareQueue queueName={queueName} className={styles.shareButton} />
         </div>
       </div>
     </div>

--- a/simplq/src/components/pages/Home/CreateJoinForm.jsx
+++ b/simplq/src/components/pages/Home/CreateJoinForm.jsx
@@ -11,7 +11,6 @@ const CreateJoinForm = ({ history }) => {
   const [textFieldValue, setTextFieldValue] = useState('');
   const [invalidMsg, setInvalidMsg] = useState('');
   const [createInProgress, setCreateInProgress] = useState(false);
-  const [joinInProgress, setJoinInProgress] = useState(false);
 
   const handleCreateClick = () => {
     if (textFieldValue === '') setInvalidMsg('Queue name is required');
@@ -31,15 +30,7 @@ const CreateJoinForm = ({ history }) => {
   const handleJoinClick = () => {
     if (textFieldValue === '') setInvalidMsg('Queue name is required');
     else {
-      setJoinInProgress(true);
-      QueueService.getStatusByName(textFieldValue)
-        .then((response) => {
-          history.push(`/j/${response.queueId}`);
-        })
-        .catch((err) => {
-          handleApiErrors(err);
-        });
-      setJoinInProgress(false);
+      history.push(`/j/${textFieldValue}`);
     }
   };
 
@@ -73,7 +64,7 @@ const CreateJoinForm = ({ history }) => {
           {createInProgress ? <LoadingIndicator /> : <CreateQButton onClick={handleCreateClick} />}
         </div>
         <div>
-          {joinInProgress ? <LoadingIndicator /> : <JoinQButton onClick={handleJoinClick} />}
+          <JoinQButton onClick={handleJoinClick} />
         </div>
       </div>
     </div>

--- a/simplq/src/components/pages/Join/index.jsx
+++ b/simplq/src/components/pages/Join/index.jsx
@@ -9,19 +9,29 @@ import PageNotFound from '../PageNotFound';
 import LoadingIndicator from '../../common/LoadingIndicator';
 
 export default function JoinQueueWithDetails(props) {
-  const queueId = props.match.params.queueId;
+  const queueName = props.match.params.queueName;
   const [queueStatusResponse, setQueueStatusResponse] = useState();
   const [error, setError] = useState(false);
   useEffect(() => {
     async function fetchData() {
-      const response = await QueueService.getStatus(queueId).catch((e) => {
+      const response = await QueueService.getStatusByName(queueName).catch((e) => {
         handleApiErrors(e);
         setError(true);
       });
       setQueueStatusResponse(response);
     }
     fetchData();
-  }, [queueId]);
+  }, [queueName]);
+
+  if (error) {
+    return <PageNotFound history={props.history} />;
+  }
+
+  if (!queueStatusResponse) {
+    return <LoadingIndicator />;
+  }
+
+  const queueId = queueStatusResponse.queueId;
 
   const joinQueueHandler = (name, contactNumber) => {
     return TokenService.create(name, contactNumber, true, queueId)
@@ -32,14 +42,6 @@ export default function JoinQueueWithDetails(props) {
         handleApiErrors(err);
       });
   };
-
-  if (error) {
-    return <PageNotFound history={props.history} />;
-  }
-
-  if (!queueStatusResponse) {
-    return <LoadingIndicator />;
-  }
 
   return (
     <div>

--- a/simplq/src/styles/homePage.module.scss
+++ b/simplq/src/styles/homePage.module.scss
@@ -101,7 +101,6 @@
   }
 }
 
-
 .queue-info {
   @include center-vertically();
   @include center-horizontally();
@@ -127,7 +126,7 @@
         margin: 0;
         padding: 0;
         justify-content: center;
-        img{
+        img {
           float: left;
           position: relative;
           bottom: -0.3rem;
@@ -136,14 +135,14 @@
           margin-right: 0.6rem;
         }
         h3 {
-          color: #3A3768;
+          color: #3a3768;
           margin: 0;
           padding: 0;
         }
         p {
           margin: 1rem;
           text-align: left;
-          color: #3A3768;
+          color: #3a3768;
           padding-left: 0.6rem;
         }
       }


### PR DESCRIPTION
Earlier we used to share links like https://new.simplq.me/j/4bf81ae6-41f4-4830-a3c9-d56de8af14ea. Post this we switch to more friendly url with the queue name http://localhost:3000/j/MyTestQueue