### PR TITLE
fix token list center vertically issue

### DIFF
--- a/simplq/src/styles/adminPage.module.scss
+++ b/simplq/src/styles/adminPage.module.scss
@@ -37,7 +37,8 @@
   @include center-horizontally();
   max-width: 40rem;
   padding: 2rem;
-  margin: auto;
+  margin: 0 auto;
+  justify-content: initial;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
This pull request fixes the problem of vertically centering the token list, 
the problem exists because two values in CSS 
```
margin: auto;
```
the margin here to need to be set only for the right and the left not the top and the right 
because setting all values to **auto** will make the token list centered horizontally and vertically so the solution is 
```
  margin: 0 auto;
```
this makes the token being centered only horizontally.

and the other problem
```
  justify-content: center;
```
this value makes the token centered vertically again because the **flex** direction is setting to **column**, so we need 
also to change this to the initial value 
so the solution is 
```
  justify-content: initial;

```