### PR TITLE
Remove horizontal centering of tokens

### DIFF
--- a/simplq/src/components/pages/Admin/index.jsx
+++ b/simplq/src/components/pages/Admin/index.jsx
@@ -90,7 +90,11 @@ export default (props) => {
       <Navbar />
       <HeaderSection />
       <div className={styles['main-body']}>
-        <div className={styles['token-list']}>
+        <div
+          className={tokens?.length > 0
+            ? styles['token-list-with-content']
+            : styles['token-list']}
+        >
           <TokenList tokens={tokens} queueId={queueId} removeTokenHandler={removeToken} />
         </div>
         <SidePanel queueId={queueId} joinQueueHandler={addNewToken} />

--- a/simplq/src/styles/adminPage.module.scss
+++ b/simplq/src/styles/adminPage.module.scss
@@ -42,6 +42,15 @@
   flex-direction: column;
 }
 
+.token-list-with-content {
+  @include center-horizontally();
+  max-width: 40rem;
+  padding: 2rem;
+  margin: 0 auto auto auto;
+  display: flex;
+  flex-direction: column;
+}
+
 .token {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Closes issue [307](https://github.com/SimplQ/simplQ-frontend/issues/307) .

Conditionally rendered the parent styles if tokens are empty.