### PR TITLE
Avoid Movement of Other Components on Expansion

### DIFF
--- a/simplq/src/components/pages/Admin/index.jsx
+++ b/simplq/src/components/pages/Admin/index.jsx
@@ -93,17 +93,13 @@ export default (props) => {
   );
 
   return (
-    <>
+    <div className={styles['admin-content']}>
       <AdminNavbar />
       <HeaderSection />
       <div className={styles['main-body']}>
-        <div
-          className={tokens?.length > 0 ? styles['token-list-with-content'] : styles['token-list']}
-        >
-          <TokenList tokens={tokens} queueId={queueId} removeTokenHandler={removeToken} />
-        </div>
+        <TokenList tokens={tokens} queueId={queueId} removeTokenHandler={removeToken} />
         <SidePanel queueId={queueId} joinQueueHandler={addNewToken} />
       </div>
-    </>
+    </div>
   );
 };

--- a/simplq/src/styles/adminPage.module.scss
+++ b/simplq/src/styles/adminPage.module.scss
@@ -173,7 +173,6 @@
 .main-body {
   display: flex;
   flex-wrap: wrap;
-  align-items: stretch;
   justify-content: center;
   margin: 3rem 6rem;
   @media screen and (max-width: 550px) {

--- a/simplq/src/styles/adminPage.module.scss
+++ b/simplq/src/styles/adminPage.module.scss
@@ -11,15 +11,6 @@
 .token-list {
   @include center-horizontally();
   max-width: 40rem;
-  padding: 2rem 0;
-  margin: auto;
-  display: flex;
-  flex-direction: column;
-}
-
-.token-list-with-content {
-  @include center-horizontally();
-  max-width: 40rem;
   padding: 2rem;
   margin: 0 auto auto auto;
   display: flex;
@@ -136,6 +127,8 @@
   }
 }
 
+.admin-content {
+  min-height: 100vh;
 .header-title {
   .sub-header {
     display: flex;
@@ -180,9 +173,11 @@
 .main-body {
   display: flex;
   flex-wrap: wrap;
+  align-items: stretch;
   justify-content: center;
   margin: 3rem 6rem;
   @media screen and (max-width: 550px) {
     margin: 2rem;
   }
+}
 }


### PR DESCRIPTION
The footer and the main content keeps moving up and down when you expand and collapse:

![ezgif com-gif-maker](https://user-images.githubusercontent.com/11256376/98436164-4289ab80-20ff-11eb-8d9c-df1f666bad40.gif)


Avoiding this by fixing the footer down below visible screen, and also not centring the text of empty queue. I tried to avoid the latter, but couldn't make both work.