### PR TITLE
Adding a new 'Get Started' section on the homepage

### DIFF
--- a/simplq/src/components/pages/Home/StaticInfos.jsx
+++ b/simplq/src/components/pages/Home/StaticInfos.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import styles from './home.module.scss';
+import StandardButton from '../../common/Button';
+import { smoothScrollToHomePageTop } from '../../common/utilFns';
 
 export const BenefitsInfo = () => (
   <div className={`${styles['section']} ${styles['benefits-info']}`}>
@@ -128,5 +130,8 @@ export const ExtraInfo = () => (
 export const GetStarted = () => (
   <div data-aos="fade-up" className={`${styles['section']} ${styles['get-started']}`}>
     <h2 data-aos="zoom-in">Ready to get started with SimplQ?</h2>
+    <div className={`${styles['button-group']}`}>
+      <StandardButton onClick={smoothScrollToHomePageTop}>Start Now</StandardButton>
+    </div>
   </div>
 );

--- a/simplq/src/components/pages/Home/StaticInfos.jsx
+++ b/simplq/src/components/pages/Home/StaticInfos.jsx
@@ -9,7 +9,7 @@ export const BenefitsInfo = () => (
     <h2 data-aos="zoom-in">Why SimplQ ?</h2>
     <div data-aos="zoom-in" className={`${styles['container']} ${styles['benefits-container']}`}>
       <div className={styles.benefit}>
-        <img src="/images/minimize_crowding.svg" alt="mimimze crowding" />
+        <img src="/images/minimize_crowding.svg" alt="minimize crowding" />
         <p>No more waiting in long lines</p>
       </div>
       <div className={styles.benefit}>
@@ -122,5 +122,11 @@ export const ExtraInfo = () => (
         </p>
       </div>
     </div>
+  </div>
+);
+
+export const GetStarted = () => (
+  <div data-aos="fade-up" className={`${styles['section']} ${styles['get-started']}`}>
+    <h2 data-aos="zoom-in">Ready to get started with SimplQ?</h2>
   </div>
 );

--- a/simplq/src/components/pages/Home/home.module.scss
+++ b/simplq/src/components/pages/Home/home.module.scss
@@ -161,6 +161,10 @@
   @extend .queue-info;
 }
 
+.get-started{
+  @extend .queue-info;
+}
+
 .extra-info {
   background-color: $primary-color-dark;
   .extra-container {

--- a/simplq/src/components/pages/Home/home.module.scss
+++ b/simplq/src/components/pages/Home/home.module.scss
@@ -163,6 +163,15 @@
 
 .get-started{
   @extend .queue-info;
+
+  .button-group {
+    @include center-horizontally();
+    flex-wrap: wrap;
+    button {
+      margin: 0.5rem 2rem;
+      min-width: 10rem;
+    }
+  }
 }
 
 .extra-info {

--- a/simplq/src/components/pages/Home/index.jsx
+++ b/simplq/src/components/pages/Home/index.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { BenefitsInfo, HowToCreate, HowToJoin, ExtraInfo } from './StaticInfos';
+import { BenefitsInfo, HowToCreate, HowToJoin, ExtraInfo, GetStarted } from './StaticInfos';
 import LandingPage from './LandingPage';
 import { smoothScrollToHomePageTop } from '../../common/utilFns';
 
@@ -13,6 +13,7 @@ const Home = () => {
       <HowToCreate />
       <HowToJoin />
       <ExtraInfo />
+      <GetStarted />
     </>
   );
 };


### PR DESCRIPTION
Adding the new section requested in issue: https://github.com/SimplQ/simplQ-frontend/issues/416
This includes adding a similar call-to-action section on the homepage which should up conversions:
![image](https://user-images.githubusercontent.com/18561224/103220771-031a5700-4919-11eb-8ff8-4635ef5fadf2.png)

**This is currently a WIP waiting for feedback on the issue about which buttons are required!**
