### PR TITLE
Removed the pencil tool icon button from admin page

### DIFF
--- a/simplq/src/components/pages/Admin/index.jsx
+++ b/simplq/src/components/pages/Admin/index.jsx
@@ -1,8 +1,6 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import React, { useState, useEffect, useCallback } from 'react';
-import IconButton from '@material-ui/core/IconButton';
-import EditIcon from '@material-ui/icons/Edit';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import TokenList from './TokenList';
 import * as TokenService from '../../../services/token';
@@ -73,9 +71,6 @@ export default (props) => {
         <Header className={styles['header']}>{queueName}</Header>
         <div className={styles['sub-header']}>
           <h2>{description}</h2>
-          <IconButton size="small">
-            <EditIcon />
-          </IconButton>
         </div>
       </div>
       <div className={styles['main-button-group']}>


### PR DESCRIPTION
Closes #455 

Since this component is not useful, it has been removed from the admin page. 
Here is what the page looks like when this component has been removed, 

![image](https://user-images.githubusercontent.com/75514064/104349395-e42ae000-5528-11eb-9a3e-a7a6d11d1431.png)
