### PR TITLE
Load site content only after auth exchange, remove min-height for loading indicator

### DIFF
--- a/simplq/src/components/Layout/index.jsx
+++ b/simplq/src/components/Layout/index.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
 import Routes from './Routes';
 import Footer from '../common/Footer';
 import styles from './layout.module.scss';
+import LoadingIndicator from '../common/LoadingIndicator';
 
 function Layout() {
+  const { isLoading } = useAuth0();
+
   return (
     <div className={styles['box']}>
-      <div className={styles['content']}>
-        <Routes />
-      </div>
+      <div className={styles['content']}>{isLoading ? <LoadingIndicator /> : <Routes />}</div>
       <div className={styles['footer']}>
         <Footer />
       </div>

--- a/simplq/src/components/Layout/layout.module.scss
+++ b/simplq/src/components/Layout/layout.module.scss
@@ -8,6 +8,8 @@
 
   .content {
     flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
   }
   .footer {
     flex: 0 1 40px;

--- a/simplq/src/components/common/LoadingIndicator/loading.module.scss
+++ b/simplq/src/components/common/LoadingIndicator/loading.module.scss
@@ -3,5 +3,4 @@
 .main {
   @include center-vertically();
   @include center-horizontally();
-  min-height: 30vh;
 }

--- a/simplq/src/components/common/LoginButton/index.jsx
+++ b/simplq/src/components/common/LoginButton/index.jsx
@@ -2,16 +2,11 @@ import React from 'react';
 import { Avatar, Button } from '@material-ui/core';
 import { useAuth0 } from '@auth0/auth0-react';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
-import LoadingIndicator from '../LoadingIndicator';
 import styles from './loginButton.module.scss';
 
 // Docs: https://auth0.com/docs/quickstart/spa/react
 const LoginButton = () => {
-  const { user, isAuthenticated, isLoading, logout, loginWithRedirect } = useAuth0();
-
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
+  const { user, isAuthenticated, logout, loginWithRedirect } = useAuth0();
 
   if (isAuthenticated) {
     return (

--- a/simplq/src/components/pages/Admin/index.jsx
+++ b/simplq/src/components/pages/Admin/index.jsx
@@ -25,7 +25,7 @@ export default (props) => {
   const [queueName, setQueueName] = useState();
   const [description, setDescription] = useState('');
   const [showQrCodeModal, setShowQrCodeModal] = useState(false);
-  const { isAuthenticated, isLoading } = useAuth0();
+  const { isAuthenticated } = useAuth0();
   const { requestMaker } = useRequest();
 
   const update = useCallback(() => {
@@ -110,7 +110,7 @@ export default (props) => {
   return (
     <div className={styles['admin-content']}>
       <HeaderSection />
-      {isAuthenticated || isLoading ? null : (
+      {isAuthenticated ? null : (
         <Ribbon
           title="Temporary queue warning!"
           subTitle="Please sign up to make your queue permanent."

--- a/simplq/src/components/pages/Home/MyQueues.jsx
+++ b/simplq/src/components/pages/Home/MyQueues.jsx
@@ -6,22 +6,17 @@ import { useAuth0 } from '@auth0/auth0-react';
 import styles from './home.module.scss';
 import { QueueRequestFactory } from '../../../api/requestFactory';
 import useRequest from '../../../api/useRequest';
-import LoadingIndicator from '../../common/LoadingIndicator';
 
 export default () => {
   const history = useHistory();
   const { requestMaker } = useRequest();
   const [myQueues, setMyQueues] = useState([]);
-  const { isAuthenticated, isLoading } = useAuth0();
+  const { isAuthenticated } = useAuth0();
 
   useEffect(() => {
     if (isAuthenticated)
       requestMaker(QueueRequestFactory.getMyQueues()).then((resp) => setMyQueues(resp.queues));
   });
-
-  if (isLoading) {
-    return <LoadingIndicator />;
-  }
 
   if (!isAuthenticated) {
     return null;


### PR DESCRIPTION
See inline comments,

1. Load the main content only after auth is done. I went this route as otherwise we would have to check everywhere before making a call if login request is completed.
2. Removed min-height, @maaverik I could not find the place where we need a minimum height... let me generate a preview url, then can you tell where we need this height? I'll also look