### PR TITLE
Refactor Token Status page to Take Data from Store Where required

### DIFF
--- a/simplq/src/components/pages/Status/LeaveQueue.jsx
+++ b/simplq/src/components/pages/Status/LeaveQueue.jsx
@@ -2,22 +2,23 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import CloseIcon from '@material-ui/icons/Close';
 import { useHistory } from 'react-router-dom';
+import { useGetToken } from 'store/asyncActions';
 import SidePanelItem from '../../common/SidePanel/SidePanelItem';
 import { setInfoPopupMessage } from '../../../store/appSlice';
 
 export default (props) => {
+  const deleteToken = useGetToken(); // fix
   const history = useHistory();
   const dispatch = useDispatch();
-  const handleClick = () => {
-    props.leaveQueueHandler().then(() => {
-      dispatch(setInfoPopupMessage('Successfully left queue'));
-      history.push(`/`);
-    });
+  const onDeleteClick = () => {
+    dispatch(deleteToken(props.tokenId));
+    dispatch(setInfoPopupMessage('Successfully left queue'));
+    history.push(`/`);
   };
 
   return (
     <SidePanelItem
-      onClick={handleClick}
+      onClick={onDeleteClick}
       Icon={CloseIcon}
       title="Leave Queue"
       description="Exit from the queue"

--- a/simplq/src/components/pages/Status/QueueDetails.jsx
+++ b/simplq/src/components/pages/Status/QueueDetails.jsx
@@ -4,16 +4,18 @@ import QueueStats from 'components/common/QueueStats';
 import { useGetQueueStatus } from 'store/asyncActions';
 import { selectQueueStatus } from 'store/queueStatus';
 import { useDispatch, useSelector } from 'react-redux';
+import { selectToken } from 'store/token';
 import SidePanelItem from '../../common/SidePanel/SidePanelItem';
 
-export default ({ queueId }) => {
+export default () => {
   const queueStatus = useSelector(selectQueueStatus);
+  const { token, loading } = useSelector(selectToken);
   const dispatch = useDispatch();
   const getQueueStatus = useCallback(useGetQueueStatus(), []);
 
   useEffect(() => {
-    dispatch(getQueueStatus({ queueId }));
-  }, [queueId, dispatch, getQueueStatus]);
+    dispatch(getQueueStatus({ queueId: token.queueId }));
+  }, [token, dispatch, getQueueStatus]);
 
   return (
     <SidePanelItem
@@ -21,7 +23,7 @@ export default ({ queueId }) => {
       title="Queue Details"
       description="Other information about the queue"
       expandable
-      loading={!queueStatus}
+      loading={loading} // Should be queueStatus's loading
     >
       <QueueStats queueStatus={queueStatus} />
     </SidePanelItem>

--- a/simplq/src/components/pages/Status/StatusContainer.jsx
+++ b/simplq/src/components/pages/Status/StatusContainer.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useGetToken } from 'store/asyncActions';
+import { selectToken } from 'store/token';
 import LoadingIndicator from '../../common/LoadingIndicator';
 import Button from '../../common/Button';
 import styles from './status.module.scss';
 
-export default ({ token }) => {
+export default () => {
+  const { token, loading } = useSelector(selectToken);
   const dispatch = useDispatch();
   const getToken = useGetToken();
 
@@ -14,8 +16,8 @@ export default ({ token }) => {
   };
 
   let status = null;
-  if (false) {
-    status = null; // TODO
+  if (loading) {
+    status = <LoadingIndicator />;
   } else if (token.tokenStatus === 'REMOVED') {
     status = <p>You have been removed from the queue, have a nice day</p>;
   } else if (token.tokenStatus === 'NOTIFIED') {
@@ -37,9 +39,6 @@ export default ({ token }) => {
       </>
     );
   }
-
-  // TODO
-  if (!status) return <LoadingIndicator />;
 
   return <div className={styles['status-box']}>{status}</div>;
 };

--- a/simplq/src/components/pages/Status/StatusSidePanel.jsx
+++ b/simplq/src/components/pages/Status/StatusSidePanel.jsx
@@ -5,11 +5,11 @@ import ContactAdmin from './ContactAdmin';
 import QueueDetails from './QueueDetails';
 import NotificationContainer from './NotificationContainer';
 
-export default (props) => (
+export default () => (
   <SidePanel>
-    <LeaveQueue leaveQueueHandler={props.leaveQueueHandler} />
+    <LeaveQueue />
     <ContactAdmin />
-    <QueueDetails queueId={props.queueId} />
+    <QueueDetails />
     <NotificationContainer />
   </SidePanel>
 );

--- a/simplq/src/components/pages/Status/TokenNumber.jsx
+++ b/simplq/src/components/pages/Status/TokenNumber.jsx
@@ -1,15 +1,24 @@
+import LoadingIndicator from 'components/common/LoadingIndicator';
 import React from 'react';
+import { useSelector } from 'react-redux';
+import { selectToken } from 'store/token';
 import styles from './status.module.scss';
 
-export default (props) => (
-  <div className={styles['token-number']}>
-    <div className={styles['hanging-threads']} />
-    <div className={styles['token-container']}>
-      <span className={styles['token']}>Token No</span>
+export default () => {
+  const { token, loading } = useSelector(selectToken);
+
+  return (
+    <div className={styles['token-number']}>
+      <div className={styles['hanging-threads']} />
+      <div className={styles['token-container']}>
+        <span className={styles['token']}>Token No</span>
+      </div>
+      <div className={styles['separator']} />
+      <div className={styles['count-container']}>
+        <span className={styles['count']}>
+          {loading ? <LoadingIndicator /> : token.tokenNumber}
+        </span>
+      </div>
     </div>
-    <div className={styles['separator']} />
-    <div className={styles['count-container']}>
-      <span className={styles['count']}>{props.tokenNumber}</span>
-    </div>
-  </div>
-);
+  );
+};

--- a/simplq/src/components/pages/Status/index.jsx
+++ b/simplq/src/components/pages/Status/index.jsx
@@ -5,7 +5,6 @@ import { selectToken } from 'store/token';
 import styles from './status.module.scss';
 import HeaderSection from '../../common/HeaderSection';
 import StatusContainer from './StatusContainer';
-import LoadingIndicator from '../../common/LoadingIndicator';
 import StatusSidePanel from './StatusSidePanel';
 import TokenNumber from './TokenNumber';
 
@@ -13,32 +12,20 @@ import TokenNumber from './TokenNumber';
 function QueueStatus(props) {
   const tokenId = props.match.params.tokenId;
   const dispatch = useDispatch();
-  const token = useSelector(selectToken);
-  // const token = {}
+  const { token, loaded } = useSelector(selectToken);
   const getToken = useGetToken();
-  const deleteToken = useGetToken();
 
   useEffect(() => {
     dispatch(getToken({ tokenId, refresh: true }));
   }, [tokenId, dispatch, getToken]);
 
-  const onDeleteClick = () => {
-    dispatch(deleteToken(tokenId));
-  };
-
-  if (token === undefined || Object.keys(token).length === 0) {
-    // TODO
-    return <LoadingIndicator />;
-  }
-
   return (
     <>
-      <HeaderSection queueName={token.queueName} />
+      <HeaderSection queueName={loaded ? token.queueName : 'Loading...'} />
       <div className={styles['main-body']}>
-        {/* should we be getting token direclty from the store from TokenNumber and StatusContainer, or is passing down info like this fine? */}
-        <TokenNumber tokenNumber={token.tokenNumber} />
-        <StatusContainer token={token} />
-        <StatusSidePanel leaveQueueHandler={onDeleteClick} queueId={token.queueId} />
+        <TokenNumber />
+        <StatusContainer />
+        <StatusSidePanel />
       </div>
     </>
   );

--- a/simplq/src/store/token/tokenSlice.js
+++ b/simplq/src/store/token/tokenSlice.js
@@ -1,14 +1,22 @@
+/* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit';
 import { getToken } from 'store/asyncActions';
 
 const tokenSlice = createSlice({
   name: 'token',
-  initialState: {},
+  initialState: {
+    token: {},
+    loaded: false,
+  },
   reducers: {},
   extraReducers: {
-    // handle fulfiled request
+    // handle fulfilled request
     [getToken.fulfilled]: (state, action) => {
-      return action.payload;
+      return { token: action.payload, loaded: true };
+    },
+    // handle pending request
+    [getToken.pending]: (state) => {
+      state.loaded = false;
     },
   },
 });


### PR DESCRIPTION
Refactor to fetch from store where data is needed, than to pass it down from main component.

- Added a `loaded` boolean field into state. Thinking of setting just this flag while loading from a network call, than setting the whole state to `{}`.
- We were loading data in the root component, wanted to see how it would look like if we fetch from store only where data is required.

Looking for feedback