### PR TITLE
Prevent failed call with queueId undefined

### DIFF
--- a/simplq/src/components/pages/TokenStatus/QueueDetails.jsx
+++ b/simplq/src/components/pages/TokenStatus/QueueDetails.jsx
@@ -14,7 +14,9 @@ export default () => {
   const token = useSelector(selectToken);
 
   useEffect(() => {
-    dispatch(getQueueStatus({ queueId: token.queueId }));
+    if (token.queueId) {
+      dispatch(getQueueStatus({ queueId: token.queueId }));
+    }
   }, [token, dispatch, getQueueStatus]);
 
   return (


### PR DESCRIPTION
Currently on page load, the queueId is not yet known, and we make call with id as undefined and fail. 

Catching it here, for now. Better ideas on fixing this it the right way is welcome