### PR TITLE
Fix Shaky Sidepanel

### DIFF
--- a/simplq/src/components/common/QueueStats/QueueStats.jsx
+++ b/simplq/src/components/common/QueueStats/QueueStats.jsx
@@ -1,23 +1,34 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useCallback, useMemo } from 'react';
 import moment from 'moment';
+import { useGetQueueStatus } from 'store/asyncActions';
+import { selectQueueStatus } from 'store/queueStatus';
+import { useDispatch, useSelector } from 'react-redux';
+import { selectTokens } from 'store/selectedQueue';
 import styles from './QueueStats.module.scss';
 
-const DetailRow = ({ title, value, large }) => (
-  <div className={styles['detail-row']}>
-    <span className={styles['detail-name']}>{title}</span>
-    <span className={`${styles['detail-value']} ${large ? styles['large-value'] : ''}`}>
-      {value}
-    </span>
-  </div>
-);
+const DetailRow = ({ title, value, large }) => {
+  return (
+    <div className={styles['detail-row']}>
+      <span className={styles['detail-name']}>{title}</span>
+      <span className={`${styles['detail-value']} ${large ? styles['large-value'] : ''}`}>
+        {value}
+      </span>
+    </div>
+  );
+};
 
-export default (props) => {
-  const {
-    status,
-    queueCreationTimestamp,
-    numberOfActiveTokens,
-    totalNumberOfTokens,
-  } = props.queueStatus;
+export default ({ queueId }) => {
+  const dispatch = useDispatch();
+  const getQueueStatus = useCallback(useGetQueueStatus(), []);
+  const tokens = useSelector(selectTokens);
+
+  useEffect(() => {
+    dispatch(getQueueStatus({ queueId }));
+  }, [queueId, tokens, dispatch, getQueueStatus]);
+
+  const { status, queueCreationTimestamp, numberOfActiveTokens, totalNumberOfTokens } = useSelector(
+    selectQueueStatus
+  );
 
   const creationTime = useMemo(() => {
     if (!queueCreationTimestamp) return '';

--- a/simplq/src/components/common/QueueStats/QueueStats.jsx
+++ b/simplq/src/components/common/QueueStats/QueueStats.jsx
@@ -6,16 +6,14 @@ import { useDispatch, useSelector } from 'react-redux';
 import { selectTokens } from 'store/selectedQueue';
 import styles from './QueueStats.module.scss';
 
-const DetailRow = ({ title, value, large }) => {
-  return (
-    <div className={styles['detail-row']}>
-      <span className={styles['detail-name']}>{title}</span>
-      <span className={`${styles['detail-value']} ${large ? styles['large-value'] : ''}`}>
-        {value}
-      </span>
-    </div>
-  );
-};
+const DetailRow = ({ title, value, large }) => (
+  <div className={styles['detail-row']}>
+    <span className={styles['detail-name']}>{title}</span>
+    <span className={`${styles['detail-value']} ${large ? styles['large-value'] : ''}`}>
+      {value}
+    </span>
+  </div>
+);
 
 export default ({ queueId }) => {
   const dispatch = useDispatch();

--- a/simplq/src/components/common/QueueStats/QueueStats.jsx
+++ b/simplq/src/components/common/QueueStats/QueueStats.jsx
@@ -23,7 +23,9 @@ export default ({ queueId }) => {
   const tokens = useSelector(selectTokens);
 
   useEffect(() => {
-    dispatch(getQueueStatus({ queueId }));
+    if (queueId) {
+      dispatch(getQueueStatus({ queueId }));
+    }
   }, [queueId, tokens, dispatch, getQueueStatus]);
 
   const { status, queueCreationTimestamp, numberOfActiveTokens, totalNumberOfTokens } = useSelector(

--- a/simplq/src/components/pages/Admin/QueueDetails.jsx
+++ b/simplq/src/components/pages/Admin/QueueDetails.jsx
@@ -1,22 +1,9 @@
-import React, { useEffect, useCallback } from 'react';
+import React from 'react';
 import InfoIcon from '@material-ui/icons/Info';
 import QueueStats from 'components/common/QueueStats';
-import { useGetQueueStatus } from 'store/asyncActions';
-import { selectQueueStatus } from 'store/queueStatus';
-import { useDispatch, useSelector } from 'react-redux';
-import { selectTokens } from 'store/selectedQueue';
 import SidePanelItem from 'components/common/SidePanel/SidePanelItem';
 
 export default ({ queueId }) => {
-  const queueStatus = useSelector(selectQueueStatus);
-  const dispatch = useDispatch();
-  const getQueueStatus = useCallback(useGetQueueStatus(), []);
-  const tokens = useSelector(selectTokens);
-
-  useEffect(() => {
-    dispatch(getQueueStatus({ queueId }));
-  }, [queueId, tokens, dispatch, getQueueStatus]);
-
   return (
     <SidePanelItem
       Icon={InfoIcon}
@@ -24,7 +11,7 @@ export default ({ queueId }) => {
       description="Other information about the queue"
       expandable
     >
-      <QueueStats queueStatus={queueStatus} />
+      <QueueStats queueId={queueId} />
     </SidePanelItem>
   );
 };

--- a/simplq/src/components/pages/TokenStatus/QueueDetails.jsx
+++ b/simplq/src/components/pages/TokenStatus/QueueDetails.jsx
@@ -14,7 +14,9 @@ export default () => {
   const token = useSelector(selectToken);
 
   useEffect(() => {
-    dispatch(getQueueStatus({ queueId: token.queueId }));
+    if (token.queueId) {
+      dispatch(getQueueStatus({ queueId: token.queueId }));
+    }
   }, [token, dispatch, getQueueStatus]);
 
   return (

--- a/simplq/src/store/queueStatus/queueStatusSlice.js
+++ b/simplq/src/store/queueStatus/queueStatusSlice.js
@@ -13,13 +13,6 @@ const queueStatusSlice = createSlice({
     [getQueueStatusByName.fulfilled]: (state, action) => {
       return action.payload;
     },
-    // handle pending request
-    [getQueueStatus.pending]: () => {
-      return {};
-    },
-    [getQueueStatusByName.pending]: () => {
-      return {};
-    },
   },
 });
 


### PR DESCRIPTION
When a request goes pending, we were setting state to `{}`. This is not required. It makes the data go empty while request is going on in the queue stats on admin page, token page etc.

While at it, I also moved the code to get the queue stats from store down into the stats component where it's required.

After this PR, the page doesn't shake anywhere, hopefully.