### PR TITLE
CSS Optimisations for small screen: Fix token and header sections

### DIFF
--- a/simplq/src/components/common/HeaderSection/HeaderSection.module.scss
+++ b/simplq/src/components/common/HeaderSection/HeaderSection.module.scss
@@ -11,6 +11,7 @@
     align-items: center;
     .header-title {
       align-items: center;
+      word-break: break-word;
     }
     .sub-header {
       margin-top: -1rem;

--- a/simplq/src/components/common/QueueInfo/QueueInfo.module.scss
+++ b/simplq/src/components/common/QueueInfo/QueueInfo.module.scss
@@ -3,14 +3,12 @@
 .detail {
   display: flex;
   flex-direction: column;
-  padding: 0.5rem 2rem;
-  max-width: 35rem;
+  padding: 2rem 0rem;
 
   .detail-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    height: 1.5rem;
 
     .detail-value {
       font-size: larger;

--- a/simplq/src/components/pages/Admin/Token.jsx
+++ b/simplq/src/components/pages/Admin/Token.jsx
@@ -106,8 +106,8 @@ function Token({ token }) {
           <div className={styles['token-icon-set']}>
             <CallButton />
             <NotifyButton />
-            <RemoveButton />
           </div>
+          <RemoveButton />
         </div>
       </div>
     </section>

--- a/simplq/src/components/pages/Admin/admin.module.scss
+++ b/simplq/src/components/pages/Admin/admin.module.scss
@@ -148,6 +148,7 @@
 .admin-content {
   min-height: 100vh;
   .header-title {
+    word-break: break-word;
     .sub-header {
       display: flex;
       font-family: Pacifico, Arial, Helvetica, sans-serif;

--- a/simplq/src/components/pages/Admin/admin.module.scss
+++ b/simplq/src/components/pages/Admin/admin.module.scss
@@ -85,6 +85,7 @@
     .token-name-time {
       text-align: left;
       align-self: center;
+      word-break: break-word;
       & > p {
         margin: 0;
 
@@ -105,8 +106,10 @@
 
       .token-icon-set {
         display: flex;
+        @media screen and (max-width: 600px) {
+          flex-direction: column;
+        }
         align-items: stretch;
-        flex-wrap: wrap;
         .token-icon {
           color: $primary-color-dark;
         }
@@ -148,7 +151,6 @@
 .admin-content {
   min-height: 100vh;
   .header-title {
-    word-break: break-word;
     .sub-header {
       display: flex;
       font-family: Pacifico, Arial, Helvetica, sans-serif;


### PR DESCRIPTION
There were minor css issues on smaller screens, which are fixed.

Also resolves #594