### PR TITLE
Merge fixes after pause queue

### DIFF
--- a/simplq/src/components/pages/Admin/AdminPage.jsx
+++ b/simplq/src/components/pages/Admin/AdminPage.jsx
@@ -13,7 +13,7 @@ import styles from './admin.module.scss';
 import SidePanel from './AdminSidePanel';
 import getToursteps from './getTourSteps';
 
-const TIMEOUT = 1000000;
+const TIMEOUT = 10000;
 let timeoutId;
 
 export default (props) => {

--- a/simplq/src/components/pages/Admin/AdminPage.jsx
+++ b/simplq/src/components/pages/Admin/AdminPage.jsx
@@ -13,7 +13,7 @@ import styles from './admin.module.scss';
 import SidePanel from './AdminSidePanel';
 import getToursteps from './getTourSteps';
 
-const TIMEOUT = 10000;
+const TIMEOUT = 1000000;
 let timeoutId;
 
 export default (props) => {

--- a/simplq/src/components/pages/Join/JoinPage.jsx
+++ b/simplq/src/components/pages/Join/JoinPage.jsx
@@ -27,10 +27,10 @@ export default ({ match }) => {
   };
 
   const onRefreshClick = () => {
-    dispatch(getQueueStatusByName({ queueName }));
+    dispatch(getQueueInfoByName({ queueName }));
   };
   const getJoinQueueOptions = () => {
-    if (queueStatus.status === 'PAUSED') {
+    if (queueInfo.status === 'PAUSED') {
       return (
         /* eslint-disable react/jsx-one-expression-per-line */
         <>

--- a/simplq/src/store/selectedQueue/selectedQueueSlice.js
+++ b/simplq/src/store/selectedQueue/selectedQueueSlice.js
@@ -5,7 +5,9 @@ import { deleteToken, getSelectedQueue, joinQueue, setQueueStatus } from 'store/
 
 const selectedQueueSlice = createSlice({
   name: 'selectedQueue',
-  initialState: {},
+  initialState: {
+    tokens: [],
+  },
   reducers: {},
   extraReducers: {
     // handle fulfiled request


### PR DESCRIPTION
Few merge fixes,

1. Use new action name after the QueueStats -> QueueInfo refactor
2. Initialise tokens in selected queue to empty array, or else the extra reducers that add and remove tokens on join/delete etc with fail on state.tokens being undefined.