### PR TITLE
Add configurable maximum queue capacity

### DIFF
--- a/simplq/.eslintrc.json
+++ b/simplq/.eslintrc.json
@@ -4,7 +4,8 @@
   "parser": "babel-eslint",
   "env": {
     "browser": true,
-    "node": true
+    "node": true,
+    "jest": true
   },
   "settings": {
     "import/resolver": {

--- a/simplq/src/api/requestFactory/index.js
+++ b/simplq/src/api/requestFactory/index.js
@@ -24,5 +24,6 @@ export {
   getQueueInfoByName,
   createQueue,
   setQueueStatus,
+  updateQueueSettings,
 } from './queue';
 export { createToken, getToken, deleteToken, notifyToken } from './token';

--- a/simplq/src/api/requestFactory/queue.js
+++ b/simplq/src/api/requestFactory/queue.js
@@ -63,3 +63,16 @@ export const setQueueStatus = (queueId, status) => ({
   url: `/queue/${queueId}`,
   data: { status },
 });
+
+/**
+ * Request creator to update queue settings
+ *
+ * @param {string} queueId
+ * @param {Object} settings
+ * @returns {Object} request - partial axios request without baseURL
+ */
+export const updateQueueSettings = (queueId, settings) => ({
+  method: 'patch',
+  url: `/queue/${queueId}`,
+  data: settings,
+});

--- a/simplq/src/components/common/Button/Button.module.scss
+++ b/simplq/src/components/common/Button/Button.module.scss
@@ -31,6 +31,13 @@
     background-size: 100%;
     transition: background 0s;
   }
+
+  &:disabled {
+    border: 1px solid #999999;
+    background-color: #cccccc;
+    color: #666666;
+    cursor: auto
+  }
 }
 
 .icon {

--- a/simplq/src/components/common/Button/Button.stories.jsx
+++ b/simplq/src/components/common/Button/Button.stories.jsx
@@ -17,3 +17,4 @@ export const OutlinedWithIcon = () => (
     Click me
   </StandardButton>
 );
+export const Disabled = () => <StandardButton disabled>Disabled</StandardButton>;

--- a/simplq/src/components/common/Button/StandardButton.jsx
+++ b/simplq/src/components/common/Button/StandardButton.jsx
@@ -2,17 +2,22 @@ import React from 'react';
 import styles from './Button.module.scss';
 
 const StandardButton = (props) => {
-  const { onClick } = props;
+  const { onClick, disabled } = props;
   return (
     <button
       type="submit"
       onClick={onClick}
+      disabled={disabled}
       className={props.outlined ? styles['standard-button-outlined'] : styles['standard-button']}
     >
       {props.icon ? <div className={styles['icon']}>{props.icon}</div> : null}
       <div className={styles['text']}>{props.children}</div>
     </button>
   );
+};
+
+StandardButton.defaultProps = {
+  disabled: false,
 };
 
 export default StandardButton;

--- a/simplq/src/components/common/Modal/Modal.jsx
+++ b/simplq/src/components/common/Modal/Modal.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Modal from '@material-ui/core/Modal';
+import { makeStyles } from '@material-ui/core/styles';
+
+const style = makeStyles((theme) => ({
+  root: {
+    overflow: 'scroll',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  content: {
+    position: 'absolute',
+    top: '20%',
+    backgroundColor: '#fff',
+    borderRadius: '25px',
+    outline: 'none',
+    width: 400,
+    padding: 10,
+    [theme.breakpoints.down('sm')]: {
+      width: '95%',
+      margin: 10,
+    },
+  },
+}));
+
+export default ({ open, onClose, children }) => {
+  const classes = style();
+  return (
+    <Modal className={classes.root} open={open} onClose={onClose}>
+      <div className={classes.content}>{children}</div>
+    </Modal>
+  );
+};

--- a/simplq/src/components/common/Modal/Modal.jsx
+++ b/simplq/src/components/common/Modal/Modal.jsx
@@ -1,34 +1,9 @@
 import React from 'react';
 import Modal from '@material-ui/core/Modal';
-import { makeStyles } from '@material-ui/core/styles';
+import styles from './Modal.module.scss';
 
-const style = makeStyles((theme) => ({
-  root: {
-    overflow: 'scroll',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  content: {
-    position: 'absolute',
-    top: '20%',
-    backgroundColor: '#fff',
-    borderRadius: '25px',
-    outline: 'none',
-    width: 400,
-    padding: 10,
-    [theme.breakpoints.down('sm')]: {
-      width: '95%',
-      margin: 10,
-    },
-  },
-}));
-
-export default ({ open, onClose, children }) => {
-  const classes = style();
-  return (
-    <Modal className={classes.root} open={open} onClose={onClose}>
-      <div className={classes.content}>{children}</div>
-    </Modal>
-  );
-};
+export default ({ open, onClose, children }) => (
+  <Modal className={styles['root']} open={open} onClose={onClose}>
+    <div className={styles['content']}>{children}</div>
+  </Modal>
+);

--- a/simplq/src/components/common/Modal/Modal.module.scss
+++ b/simplq/src/components/common/Modal/Modal.module.scss
@@ -11,12 +11,12 @@
   position: absolute;
   top: 20%;
   background-color: #fff;
-  border-radius: 25px;
+  border-radius: 1.5rem;
   outline: none;
   width: 400px;
-  padding: 10px;
+  padding: 0.6rem;
   @media (max-width: 960px) {
     width: 95%;
-    margin: 10px;
+    margin: 0.6rem;
   }
 }

--- a/simplq/src/components/common/Modal/Modal.module.scss
+++ b/simplq/src/components/common/Modal/Modal.module.scss
@@ -1,0 +1,22 @@
+@import 'components/common.scss';
+
+.root {
+  overflow: scroll;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.content {
+  position: absolute;
+  top: 20%;
+  background-color: #fff;
+  border-radius: 25px;
+  outline: none;
+  width: 400px;
+  padding: 10px;
+  @media (max-width: 960px) {
+    width: 95%;
+    margin: 10px;
+  }
+}

--- a/simplq/src/components/common/Modal/Modal.stories.jsx
+++ b/simplq/src/components/common/Modal/Modal.stories.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+import Modal from '.';
+import Button from '../Button';
+
+export default {
+  component: Modal,
+  title: 'Modal',
+};
+
+export const Normal = () => (
+  <Modal open>
+    <Grid container direction="column">
+      <h2>Delete Account</h2>
+      <p>Are you sure you want to delete your account?</p>
+      <div style={{ display: 'flex', justifyContent: 'space-evenly' }}>
+        <Button>Cancel</Button>
+        <Button>Delete</Button>
+      </div>
+    </Grid>
+  </Modal>
+);

--- a/simplq/src/components/common/Modal/Modal.test.jsx
+++ b/simplq/src/components/common/Modal/Modal.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Modal from '.';
+
+describe('Modal', () => {
+  it('should render the modal if it is open', () => {
+    const { getByText } = render(<Modal open>Hello</Modal>);
+    getByText('Hello');
+  });
+
+  it('should not render the modal if it is not open', () => {
+    const { queryByText } = render(<Modal open={false}>Hello</Modal>);
+    expect(queryByText('Hello')).toBeFalsy();
+  });
+});

--- a/simplq/src/components/common/Modal/index.jsx
+++ b/simplq/src/components/common/Modal/index.jsx
@@ -1,0 +1,3 @@
+import Modal from './Modal';
+
+export default Modal;

--- a/simplq/src/components/common/Popup/QrCode.jsx
+++ b/simplq/src/components/common/Popup/QrCode.jsx
@@ -1,10 +1,11 @@
 import React, { useRef, forwardRef } from 'react';
-import { makeStyles, Modal, useMediaQuery } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core';
 import { QRCode } from 'react-qrcode-logo';
 import PrintIcon from '@material-ui/icons/Print';
 import HighlightOffIcon from '@material-ui/icons/HighlightOff';
 import { useReactToPrint } from 'react-to-print';
 import { getSentenceCaseText } from 'utils/textOperations';
+import Modal from '../Modal';
 import StandardButton from '../Button';
 
 const ComponentToPrint = forwardRef(({ style, url, queueName }, ref) => {
@@ -28,8 +29,6 @@ const ComponentToPrint = forwardRef(({ style, url, queueName }, ref) => {
 const QrCode = (props) => {
   const { queueName, show, onClose } = props;
 
-  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'));
-
   const componentPrintRef = useRef();
 
   const handlePrint = useReactToPrint({
@@ -38,16 +37,6 @@ const QrCode = (props) => {
 
   const styles = makeStyles(() => {
     return {
-      modalContainer: {
-        position: 'absolute',
-        top: '20%',
-        backgroundColor: '#fff',
-        borderRadius: '25px',
-        outline: 'none',
-        width: isMobile ? '95%' : 400,
-        padding: 10,
-        margin: isMobile ? 10 : 0,
-      },
       centered: {
         display: 'flex',
         alignItems: 'center',
@@ -67,32 +56,21 @@ const QrCode = (props) => {
   const handleModalClose = () => onClose(false);
 
   return (
-    <Modal
-      style={{
-        overflow: 'scroll',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-      open={queueName ? show : !show}
-      onClose={handleModalClose}
-    >
-      <div className={styles['modalContainer']}>
-        <div className={styles['centered']}>
-          <ComponentToPrint
-            style={styles['centered']}
-            url={`${window.location.origin}/j/${queueName}`}
-            queueName={queueName}
-            ref={componentPrintRef}
-          />
-          <div className={styles['actionContainer']}>
-            <StandardButton onClick={handlePrint} icon={<PrintIcon />}>
-              Print
-            </StandardButton>
-            <StandardButton onClick={handleModalClose} icon={<HighlightOffIcon />} outlined>
-              Close
-            </StandardButton>
-          </div>
+    <Modal open={queueName ? show : !show} onClose={handleModalClose}>
+      <div className={styles['centered']}>
+        <ComponentToPrint
+          style={styles['centered']}
+          url={`${window.location.origin}/j/${queueName}`}
+          queueName={queueName}
+          ref={componentPrintRef}
+        />
+        <div className={styles['actionContainer']}>
+          <StandardButton onClick={handlePrint} icon={<PrintIcon />}>
+            Print
+          </StandardButton>
+          <StandardButton onClick={handleModalClose} icon={<HighlightOffIcon />} outlined>
+            Close
+          </StandardButton>
         </div>
       </div>
     </Modal>

--- a/simplq/src/components/pages/Admin/AdminSidePanel.jsx
+++ b/simplq/src/components/pages/Admin/AdminSidePanel.jsx
@@ -5,6 +5,7 @@ import AddMember from './AddMember';
 import PauseQueue from './PauseQueue';
 import DeleteQueue from './DeleteQueue';
 import QueueHistory from './QueueHistory';
+import QueueSettings from './QueueSettings';
 
 export default ({ queueId }) => (
   <SidePanel>
@@ -13,5 +14,6 @@ export default ({ queueId }) => (
     <DeleteQueue queueId={queueId} />
     <QueueHistory />
     <QueueDetails queueId={queueId} />
+    <QueueSettings queueId={queueId} />
   </SidePanel>
 );

--- a/simplq/src/components/pages/Admin/QueueSettings.jsx
+++ b/simplq/src/components/pages/Admin/QueueSettings.jsx
@@ -8,8 +8,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import Grid from '@material-ui/core/Grid';
 import SaveIcon from '@material-ui/icons/Save';
 import { selectMaxQueueCapacity } from 'store/selectedQueue';
-import Button from '../../common/Button';
-import InputField from '../../common/InputField';
+import Button from 'components/common/Button';
+import InputField from 'components/common/InputField';
 import styles from './QueueSettings.module.scss';
 
 const MAX_SIZE = 100000;
@@ -38,9 +38,13 @@ export default ({ queueId }) => {
 
   const toggleModal = () => setIsModalOpen((isOpen) => !isOpen);
 
-  const handleSave = () => {
-    dispatch(updateSettings({ queueId, settings: { maxQueueCapacity: size } }));
-    toggleModal();
+  const handleSave = async () => {
+    const response = await dispatch(
+      updateSettings({ queueId, settings: { maxQueueCapacity: size } })
+    );
+    if (!response.error) {
+      toggleModal();
+    }
   };
   return (
     <>

--- a/simplq/src/components/pages/Admin/QueueSettings.jsx
+++ b/simplq/src/components/pages/Admin/QueueSettings.jsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import SettingsIcon from '@material-ui/icons/Settings';
+import Modal from 'components/common/Modal';
+import PrintIcon from '@material-ui/icons/Print';
+import HighlightOffIcon from '@material-ui/icons/HighlightOff';
+import { makeStyles } from '@material-ui/core/styles';
+import SidePanelItem from 'components/common/SidePanel/SidePanelItem';
+import { useUpdateQueueSettings } from 'store/asyncActions';
+import { useDispatch } from 'react-redux';
+import Grid from '@material-ui/core/Grid';
+import Button from '../../common/Button';
+import InputField from '../../common/InputField';
+
+const style = makeStyles((theme) => ({
+  modalContent: {
+    display: 'flex',
+    padding: theme.spacing(1),
+  },
+  actionContainer: {
+    display: 'flex',
+    justifyContent: 'space-evenly',
+  },
+  title: {
+    display: 'flex',
+    justifyContent: 'center',
+    textDecoration: 'underline',
+  },
+  sizeInput: {
+    marginBottom: theme.spacing(3),
+  },
+}));
+
+const MAX_SIZE = 100000;
+
+export default ({ queueId }) => {
+  const classes = style();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [size, setSize] = React.useState(1);
+
+  const handleSizeChange = (e) => {
+    const positiveInteger = /^\d+$/i;
+    const input = positiveInteger.test(e.target.value) ? e.target.value : 0;
+    setSize(input);
+  };
+
+  const isInvalidSize = () => {
+    return size < 1 || size > MAX_SIZE;
+  };
+
+  const dispatch = useDispatch();
+  const updateSettings = useUpdateQueueSettings();
+
+  const toggleModal = () => setIsModalOpen((isOpen) => !isOpen);
+
+  const handleSave = () => {
+    dispatch(updateSettings({ queueId, settings: { maxQueueCapacity: size } }));
+  };
+  return (
+    <>
+      <SidePanelItem Icon={SettingsIcon} title="Queue Settings" onClick={toggleModal} />
+      <Modal open={isModalOpen}>
+        <Grid container className={classes.modalContent} direction="column">
+          <h2 className={classes.title}>Settings</h2>
+          <InputField
+            inputProps={{ 'data-testid': 'size-input' }}
+            className={classes.sizeInput}
+            label="Maximum Queue Capacity"
+            value={size}
+            type="number"
+            onChange={handleSizeChange}
+            error={isInvalidSize()}
+            helperText={isInvalidSize() && `Enter a number between 1 and ${MAX_SIZE}`}
+            autoFocus
+          />
+          <div className={classes.actionContainer}>
+            <Button icon={<PrintIcon />} onClick={handleSave} disabled={isInvalidSize()}>
+              Save
+            </Button>
+            <Button icon={<HighlightOffIcon />} onClick={toggleModal} outlined>
+              Close
+            </Button>
+          </div>
+        </Grid>
+      </Modal>
+    </>
+  );
+};

--- a/simplq/src/components/pages/Admin/QueueSettings.jsx
+++ b/simplq/src/components/pages/Admin/QueueSettings.jsx
@@ -1,41 +1,27 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import SettingsIcon from '@material-ui/icons/Settings';
 import Modal from 'components/common/Modal';
-import PrintIcon from '@material-ui/icons/Print';
 import HighlightOffIcon from '@material-ui/icons/HighlightOff';
-import { makeStyles } from '@material-ui/core/styles';
 import SidePanelItem from 'components/common/SidePanel/SidePanelItem';
 import { useUpdateQueueSettings } from 'store/asyncActions';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import Grid from '@material-ui/core/Grid';
+import SaveIcon from '@material-ui/icons/Save';
+import { selectMaxQueueCapacity } from 'store/selectedQueue';
 import Button from '../../common/Button';
 import InputField from '../../common/InputField';
-
-const style = makeStyles((theme) => ({
-  modalContent: {
-    display: 'flex',
-    padding: theme.spacing(1),
-  },
-  actionContainer: {
-    display: 'flex',
-    justifyContent: 'space-evenly',
-  },
-  title: {
-    display: 'flex',
-    justifyContent: 'center',
-    textDecoration: 'underline',
-  },
-  sizeInput: {
-    marginBottom: theme.spacing(3),
-  },
-}));
+import styles from './QueueSettings.module.scss';
 
 const MAX_SIZE = 100000;
 
 export default ({ queueId }) => {
-  const classes = style();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [size, setSize] = React.useState(1);
+  const maxQueueSize = useSelector(selectMaxQueueCapacity);
+  const [size, setSize] = React.useState(maxQueueSize);
+
+  useEffect(() => {
+    setSize(maxQueueSize);
+  }, [maxQueueSize]);
 
   const handleSizeChange = (e) => {
     const positiveInteger = /^\d+$/i;
@@ -54,16 +40,17 @@ export default ({ queueId }) => {
 
   const handleSave = () => {
     dispatch(updateSettings({ queueId, settings: { maxQueueCapacity: size } }));
+    toggleModal();
   };
   return (
     <>
       <SidePanelItem Icon={SettingsIcon} title="Queue Settings" onClick={toggleModal} />
       <Modal open={isModalOpen}>
-        <Grid container className={classes.modalContent} direction="column">
-          <h2 className={classes.title}>Settings</h2>
+        <Grid container className={styles['modal-content']} direction="column">
+          <h2 className={styles['title']}>Settings</h2>
           <InputField
             inputProps={{ 'data-testid': 'size-input' }}
-            className={classes.sizeInput}
+            className={styles['size-input']}
             label="Maximum Queue Capacity"
             value={size}
             type="number"
@@ -72,8 +59,8 @@ export default ({ queueId }) => {
             helperText={isInvalidSize() && `Enter a number between 1 and ${MAX_SIZE}`}
             autoFocus
           />
-          <div className={classes.actionContainer}>
-            <Button icon={<PrintIcon />} onClick={handleSave} disabled={isInvalidSize()}>
+          <div className={styles['action-container']}>
+            <Button icon={<SaveIcon />} onClick={handleSave} disabled={isInvalidSize()}>
               Save
             </Button>
             <Button icon={<HighlightOffIcon />} onClick={toggleModal} outlined>

--- a/simplq/src/components/pages/Admin/QueueSettings.module.scss
+++ b/simplq/src/components/pages/Admin/QueueSettings.module.scss
@@ -1,0 +1,20 @@
+@import 'components/common.scss';
+
+.modal-content {
+  padding: 8px;
+}
+
+.title {
+  display: flex;
+  justify-content: center;
+  text-decoration: underline;
+}
+
+.size-input {
+  margin-bottom: 24px;
+}
+
+.action-container {
+  display: flex;
+  justify-content: space-evenly;
+}

--- a/simplq/src/components/pages/Admin/QueueSettings.module.scss
+++ b/simplq/src/components/pages/Admin/QueueSettings.module.scss
@@ -1,7 +1,7 @@
 @import 'components/common.scss';
 
 .modal-content {
-  padding: 8px;
+  padding: .5rem;
 }
 
 .title {
@@ -11,7 +11,7 @@
 }
 
 .size-input {
-  margin-bottom: 24px;
+  margin-bottom: 1.5rem;
 }
 
 .action-container {

--- a/simplq/src/components/pages/Admin/__tests__/AdminSidePanel.test.jsx
+++ b/simplq/src/components/pages/Admin/__tests__/AdminSidePanel.test.jsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import AdminSidePanel from '../AdminSidePanel';
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => jest.fn(),
+  useSelector: () => 'pending',
+}));
+
+describe('Admin Side Panel', () => {
+  it('should render the component', () => {
+    const { getByText } = render(<AdminSidePanel queueId="d3-220c-4b" />);
+    getByText('Queue Settings');
+  });
+});

--- a/simplq/src/components/pages/Admin/__tests__/QueueSettings.test.jsx
+++ b/simplq/src/components/pages/Admin/__tests__/QueueSettings.test.jsx
@@ -4,11 +4,15 @@ import QueueSettings from '../QueueSettings';
 
 jest.mock('react-redux', () => ({
   useDispatch: () => jest.fn(),
+  useSelector: (arg) => arg,
 }));
 
 const mockUpdateSettings = jest.fn();
 jest.mock('store/asyncActions', () => ({
   useUpdateQueueSettings: () => mockUpdateSettings,
+}));
+jest.mock('store/selectedQueue', () => ({
+  selectMaxQueueCapacity: () => 10,
 }));
 
 describe('Queue settings', () => {
@@ -42,7 +46,7 @@ describe('Queue settings', () => {
       expect(mockUpdateSettings).toHaveBeenCalledTimes(1);
       expect(mockUpdateSettings).toHaveBeenCalledWith({
         queueId: 'd3-220c-4b',
-        settings: { maxQueueCapacity: 1 },
+        settings: { maxQueueCapacity: 10 },
       });
     });
 

--- a/simplq/src/components/pages/Admin/__tests__/QueueSettings.test.jsx
+++ b/simplq/src/components/pages/Admin/__tests__/QueueSettings.test.jsx
@@ -1,0 +1,85 @@
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import QueueSettings from '../QueueSettings';
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => jest.fn(),
+}));
+
+const mockUpdateSettings = jest.fn();
+jest.mock('store/asyncActions', () => ({
+  useUpdateQueueSettings: () => mockUpdateSettings,
+}));
+
+describe('Queue settings', () => {
+  it('on click component should open a modal', () => {
+    const { getByTestId, getByText } = render(<QueueSettings />);
+    getByText('Queue Settings').click();
+    getByTestId('size-input');
+  });
+
+  describe('Modal', () => {
+    let queryById;
+    let getText;
+    let queryText;
+    beforeEach(() => {
+      const { queryByTestId, getByText, queryByText } = render(
+        <QueueSettings queueId="d3-220c-4b" />
+      );
+      getText = getByText;
+      queryById = queryByTestId;
+      queryText = queryByText;
+      getByText('Queue Settings').click();
+    });
+
+    it('on click close button should close the modal', () => {
+      getText('Close').click();
+      expect(queryById('size-input')).toBeFalsy();
+    });
+
+    it('on click save button should update the settings', () => {
+      getText('Save').click();
+      expect(mockUpdateSettings).toHaveBeenCalledTimes(1);
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        queueId: 'd3-220c-4b',
+        settings: { maxQueueCapacity: 1 },
+      });
+    });
+
+    it('Invalid queue settings should disable the save button', () => {
+      const field = queryById('size-input');
+      fireEvent.change(field, { target: { value: -1 } });
+      expect(getText('Save')).toBeDisabled();
+    });
+
+    describe('Queue capacity input field', () => {
+      it('A valid size should not throw any error', () => {
+        const field = queryById('size-input');
+        fireEvent.change(field, { target: { value: 13 } });
+        expect(queryText('Enter a number between 1 and 100000')).toBeFalsy();
+      });
+
+      it('An invalid size should throw an error', () => {
+        const field = queryById('size-input');
+        fireEvent.change(field, { target: { value: 'ram' } });
+        expect(queryText('Enter a number between 1 and 100000')).toBeTruthy();
+      });
+
+      it('A valid input should update the field', () => {
+        const field = queryById('size-input');
+        fireEvent.change(field, { target: { value: 99 } });
+        expect(field.value).toEqual('99');
+      });
+
+      it('An invalid input should make the value zero', () => {
+        const field = queryById('size-input');
+        fireEvent.change(field, { target: { value: 'abc' } });
+        expect(field.value).toEqual('0');
+        fireEvent.change(field, { target: { value: -1 } });
+        expect(field.value).toEqual('0');
+        fireEvent.change(field, { target: { value: 5.9 } });
+        expect(field.value).toEqual('0');
+      });
+    });
+  });
+});

--- a/simplq/src/store/asyncActions/__test__/updateQueueSettings.test.js
+++ b/simplq/src/store/asyncActions/__test__/updateQueueSettings.test.js
@@ -1,0 +1,18 @@
+import { useUpdateQueueSettings } from '..';
+
+jest.mock('api/auth', () => ({
+  useMakeAuthedRequest: () => (fn) => fn,
+}));
+
+describe('Update queue settings', () => {
+  it('should return update queue settings action', async () => {
+    const updateSettings = useUpdateQueueSettings();
+    const thunk = updateSettings({ queueId: 'd3-220c-4b', settings: { maxQueueCapacity: 4 } });
+    const action = await thunk(jest.fn());
+    expect(action.payload).toEqual({
+      method: 'patch',
+      url: '/queue/d3-220c-4b',
+      data: { maxQueueCapacity: 4 },
+    });
+  });
+});

--- a/simplq/src/store/asyncActions/index.js
+++ b/simplq/src/store/asyncActions/index.js
@@ -13,6 +13,7 @@ export { joinQueue, useJoinQueue } from './joinQueue';
 export { getSelectedQueue, useGetSelectedQueue } from './getSelectedQueue';
 export { createQueue, useCreateQueue } from './createQueue';
 export { setQueueStatus, useSetQueueStatus } from './setQueueStatus';
+export { default as useUpdateQueueSettings } from './updateQueueSettings';
 
 export { getToken, useGetToken } from './getToken';
 export { deleteToken, useDeleteToken } from './deleteToken';

--- a/simplq/src/store/asyncActions/index.js
+++ b/simplq/src/store/asyncActions/index.js
@@ -13,7 +13,7 @@ export { joinQueue, useJoinQueue } from './joinQueue';
 export { getSelectedQueue, useGetSelectedQueue } from './getSelectedQueue';
 export { createQueue, useCreateQueue } from './createQueue';
 export { setQueueStatus, useSetQueueStatus } from './setQueueStatus';
-export { default as useUpdateQueueSettings } from './updateQueueSettings';
+export { updateQueueSettings, useUpdateQueueSettings } from './updateQueueSettings';
 
 export { getToken, useGetToken } from './getToken';
 export { deleteToken, useDeleteToken } from './deleteToken';

--- a/simplq/src/store/asyncActions/updateQueueSettings.js
+++ b/simplq/src/store/asyncActions/updateQueueSettings.js
@@ -18,4 +18,6 @@ const useUpdateQueueSettings = () => {
   return updateQueueSettings;
 };
 
-export default useUpdateQueueSettings;
+const updateQueueSettings = createAsyncThunk(typePrefix);
+
+export { useUpdateQueueSettings, updateQueueSettings };

--- a/simplq/src/store/asyncActions/updateQueueSettings.js
+++ b/simplq/src/store/asyncActions/updateQueueSettings.js
@@ -1,0 +1,21 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { useMakeAuthedRequest } from 'api/auth';
+import * as RequestFactory from 'api/requestFactory';
+
+const typePrefix = 'updateQueueSettings/action';
+
+/**
+ * A hook to access the updateQueueSettings async action creator.
+ *
+ * @returns — updateQueueSettings async action creator
+ */
+const useUpdateQueueSettings = () => {
+  const makeAuthedRequest = useMakeAuthedRequest();
+  const updateQueueSettings = createAsyncThunk(typePrefix, async (arg) => {
+    const { queueId, settings } = arg;
+    return makeAuthedRequest(RequestFactory.updateQueueSettings(queueId, settings));
+  });
+  return updateQueueSettings;
+};
+
+export default useUpdateQueueSettings;

--- a/simplq/src/store/selectedQueue/index.js
+++ b/simplq/src/store/selectedQueue/index.js
@@ -2,4 +2,9 @@ import reducer from './selectedQueueSlice';
 
 export default reducer;
 
-export { selectQueueName, selectTokens, selectQueueStatus } from './selectedQueueSlice';
+export {
+  selectQueueName,
+  selectTokens,
+  selectQueueStatus,
+  selectMaxQueueCapacity,
+} from './selectedQueueSlice';

--- a/simplq/src/store/selectedQueue/selectedQueueSlice.js
+++ b/simplq/src/store/selectedQueue/selectedQueueSlice.js
@@ -1,7 +1,13 @@
 /* eslint-disable no-param-reassign */
 
 import { createSlice } from '@reduxjs/toolkit';
-import { deleteToken, getSelectedQueue, joinQueue, setQueueStatus } from 'store/asyncActions';
+import {
+  deleteToken,
+  getSelectedQueue,
+  joinQueue,
+  setQueueStatus,
+  updateQueueSettings,
+} from 'store/asyncActions';
 
 const selectedQueueSlice = createSlice({
   name: 'selectedQueue',
@@ -10,7 +16,7 @@ const selectedQueueSlice = createSlice({
   },
   reducers: {},
   extraReducers: {
-    // handle fulfiled request
+    // handle fulfilled request
     [getSelectedQueue.fulfilled]: (state, action) => {
       return action.payload;
     },
@@ -29,6 +35,11 @@ const selectedQueueSlice = createSlice({
       state.status = action.payload.status;
       return state;
     },
+    // update queue settings
+    [updateQueueSettings.fulfilled]: (state, action) => {
+      state.maxQueueCapacity = action.payload.maxQueueCapacity;
+      return state;
+    },
   },
 });
 
@@ -39,3 +50,5 @@ export const selectQueueName = (state) => state.selectedQueue.queueName;
 export const selectTokens = (state) => state.selectedQueue.tokens;
 
 export const selectQueueStatus = (state) => state.selectedQueue.status;
+
+export const selectMaxQueueCapacity = (state) => state.selectedQueue.maxQueueCapacity;


### PR DESCRIPTION
This PR implements the configurable maximum queue capacity feature(#425 )
- Moved out `Modal` to the common directory
- Added `disabled` prop in `Button`
- Created `QueueSettings` component which has the side panel option and the settings modal

Screenshots
<img width="949" alt="Q1" src="https://user-images.githubusercontent.com/35535357/114272051-123d9480-9a32-11eb-8cb3-a6e83a470871.PNG">
<img width="958" alt="Q2" src="https://user-images.githubusercontent.com/35535357/114272053-14075800-9a32-11eb-933f-3e37ad74c7b9.PNG">
<img width="960" alt="Q3" src="https://user-images.githubusercontent.com/35535357/114272056-18cc0c00-9a32-11eb-8755-17a077f1e11b.PNG">
