### PR TITLE
Fix for back button not working on 404 page

### DIFF
--- a/simplq/src/components/pages/Join/JoinPage.jsx
+++ b/simplq/src/components/pages/Join/JoinPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { useGetQueueInfoByName, useJoinQueue } from 'store/asyncActions';
 import { selectQueueInfo } from 'store/queueInfo';
 import HeaderSection from 'components/common/HeaderSection';
@@ -16,8 +17,12 @@ export default ({ match }) => {
   const dispatch = useDispatch();
   const queueInfo = useSelector(selectQueueInfo);
 
+  const history = useHistory();
+
   useEffect(() => {
-    dispatch(getQueueInfoByName({ queueName }));
+    if (history.action === 'POP') {
+      history.push('/');
+    } else dispatch(getQueueInfoByName({ queueName }));
   }, [queueName, dispatch, getQueueInfoByName]);
 
   const queueId = queueInfo.queueId;


### PR DESCRIPTION
On clicking join queue button, we are routing to **JoinPage** which dispatches the **getQueueInfoByName** action in its useEffect hook. 
If it fails there, we are redirecting to 404 page. 

The issue now occurs, if we click on back button, we are _going back to JoinPage_ and which _again dispatches the action_ on useEffect. This then _redirects back to 404 page_ and so on, **cyclically**.

I have added a check in the useEffect of JoinPage, to check if the **history action is POP**, which **if true will redirect to home page**, and only if not, will the get queue action be dispatched. 
This might not be the correct way to go about it, but I wasn't able to find a way to get the previous location and do checks on that, without having to store it, which in this case seemed kind of an overkill for me.