### PR TITLE
Add queue capacity in queue information section

### DIFF
--- a/simplq/src/components/common/QueueInfo/QueueInfo.jsx
+++ b/simplq/src/components/common/QueueInfo/QueueInfo.jsx
@@ -6,10 +6,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import { selectTokens, selectMaxQueueCapacity } from 'store/selectedQueue';
 import styles from './QueueInfo.module.scss';
 
-const DetailRow = ({ title, value, large }) => (
+const DetailRow = ({ title, value, large, valueId }) => (
   <div className={styles['detail-row']}>
     <span className={styles['detail-name']}>{title}</span>
-    <span className={`${styles['detail-value']} ${large ? styles['large-value'] : ''}`}>
+    <span
+      className={`${styles['detail-value']} ${large ? styles['large-value'] : ''}`}
+      data-testid={valueId}
+    >
       {value}
     </span>
   </div>
@@ -30,7 +33,7 @@ export default ({ queueId }) => {
     selectQueueInfo
   );
 
-  const queueCapacity = useSelector(selectMaxQueueCapacity);
+  const availableSlots = useSelector(selectMaxQueueCapacity) - numberOfActiveTokens;
 
   const creationTime = useMemo(() => {
     if (!queueCreationTimestamp) return '';
@@ -42,7 +45,7 @@ export default ({ queueId }) => {
   return (
     <div className={styles['detail']}>
       <DetailRow title="Queue status:" value={status} />
-      <DetailRow title="Queue capacity:" value={queueCapacity} large />
+      <DetailRow title="Available Slots:" value={availableSlots} large valueId="slots-value" />
       <DetailRow title="People currently in queue:" value={numberOfActiveTokens} large />
       <DetailRow title="Total number of people joined in queue:" value={totalNumberOfTokens} />
       <DetailRow title="Queue creation time:" value={creationTime} />

--- a/simplq/src/components/common/QueueInfo/QueueInfo.jsx
+++ b/simplq/src/components/common/QueueInfo/QueueInfo.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { useGetQueueInfo } from 'store/asyncActions';
 import { selectQueueInfo } from 'store/queueInfo';
 import { useDispatch, useSelector } from 'react-redux';
-import { selectTokens } from 'store/selectedQueue';
+import { selectTokens, selectMaxQueueCapacity } from 'store/selectedQueue';
 import styles from './QueueInfo.module.scss';
 
 const DetailRow = ({ title, value, large }) => (
@@ -30,6 +30,8 @@ export default ({ queueId }) => {
     selectQueueInfo
   );
 
+  const queueCapacity = useSelector(selectMaxQueueCapacity);
+
   const creationTime = useMemo(() => {
     if (!queueCreationTimestamp) return '';
 
@@ -40,6 +42,7 @@ export default ({ queueId }) => {
   return (
     <div className={styles['detail']}>
       <DetailRow title="Queue status:" value={status} />
+      <DetailRow title="Queue capacity:" value={queueCapacity} large />
       <DetailRow title="People currently in queue:" value={numberOfActiveTokens} large />
       <DetailRow title="Total number of people joined in queue:" value={totalNumberOfTokens} />
       <DetailRow title="Queue creation time:" value={creationTime} />

--- a/simplq/src/components/common/QueueInfo/QueueInfo.test.jsx
+++ b/simplq/src/components/common/QueueInfo/QueueInfo.test.jsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import QueueInfo from '.';
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: (arg) => arg,
+}));
+jest.mock('store/asyncActions', () => ({
+  useGetQueueInfo: jest.fn(),
+}));
+jest.mock('store/selectedQueue', () => ({
+  selectMaxQueueCapacity: 57,
+}));
+jest.mock('store/queueInfo', () => ({
+  selectQueueInfo: jest.fn(),
+}));
+
+describe('Queue info', () => {
+  it('should render queue capacity', () => {
+    const { getByText } = render(<QueueInfo />);
+    getByText('57');
+  });
+});

--- a/simplq/src/components/common/QueueInfo/QueueInfo.test.jsx
+++ b/simplq/src/components/common/QueueInfo/QueueInfo.test.jsx
@@ -13,12 +13,12 @@ jest.mock('store/selectedQueue', () => ({
   selectMaxQueueCapacity: 57,
 }));
 jest.mock('store/queueInfo', () => ({
-  selectQueueInfo: jest.fn(),
+  selectQueueInfo: { numberOfActiveTokens: 24 },
 }));
 
 describe('Queue info', () => {
-  it('should render queue capacity', () => {
-    const { getByText } = render(<QueueInfo />);
-    getByText('57');
+  it('should render available queue slots', () => {
+    const { getByTestId } = render(<QueueInfo />);
+    expect(getByTestId('slots-value')).toHaveTextContent('33');
   });
 });


### PR DESCRIPTION
This PR adds the queue capacity in queue info section as discussed in #603 .
<img width="294" alt="size" src="https://user-images.githubusercontent.com/35535357/115247177-30974480-a144-11eb-982a-939579bc1b3a.png">
