### PR TITLE
(bugfix) - Available slots is undefined in Ready to Join page

### DIFF
--- a/simplq/src/components/common/QueueInfo/QueueInfo.jsx
+++ b/simplq/src/components/common/QueueInfo/QueueInfo.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { useGetQueueInfo } from 'store/asyncActions';
 import { selectQueueInfo } from 'store/queueInfo';
 import { useDispatch, useSelector } from 'react-redux';
-import { selectTokens, selectMaxQueueCapacity } from 'store/selectedQueue';
+import { selectTokens } from 'store/selectedQueue';
 import styles from './QueueInfo.module.scss';
 
 const DetailRow = ({ title, value, large, valueId }) => (
@@ -29,11 +29,15 @@ export default ({ queueId }) => {
     }
   }, [queueId, tokens, dispatch, getQueueInfo]);
 
-  const { status, queueCreationTimestamp, numberOfActiveTokens, totalNumberOfTokens } = useSelector(
-    selectQueueInfo
-  );
+  const {
+    status,
+    queueCreationTimestamp,
+    numberOfActiveTokens,
+    totalNumberOfTokens,
+    maxQueueCapacity,
+  } = useSelector(selectQueueInfo);
 
-  const availableSlots = useSelector(selectMaxQueueCapacity) - numberOfActiveTokens;
+  const availableSlots = maxQueueCapacity - numberOfActiveTokens;
 
   const creationTime = useMemo(() => {
     if (!queueCreationTimestamp) return '';

--- a/simplq/src/components/common/QueueInfo/QueueInfo.test.jsx
+++ b/simplq/src/components/common/QueueInfo/QueueInfo.test.jsx
@@ -9,11 +9,9 @@ jest.mock('react-redux', () => ({
 jest.mock('store/asyncActions', () => ({
   useGetQueueInfo: jest.fn(),
 }));
-jest.mock('store/selectedQueue', () => ({
-  selectMaxQueueCapacity: 57,
-}));
+jest.mock('store/selectedQueue', () => ({}));
 jest.mock('store/queueInfo', () => ({
-  selectQueueInfo: { numberOfActiveTokens: 24 },
+  selectQueueInfo: { maxQueueCapacity: 57, numberOfActiveTokens: 24 },
 }));
 
 describe('Queue info', () => {


### PR DESCRIPTION
**BUG** - Available slots is showing `NaN` since `selectMaxQueueCapacity` is returning undefined in the Ready to Join page.

<img width="950" alt="slots" src="https://user-images.githubusercontent.com/35535357/115955433-f814b380-a513-11eb-90b0-d7dc5dd3a569.PNG">

**FIX** - Replace `selectMaxQueueCapacity` with `selectQueueInfo` to get queue capacity.