### PR TITLE
Modified admin page to display QR code when empty

### DIFF
--- a/simplq/src/components/common/Popup/QrCode.jsx
+++ b/simplq/src/components/common/Popup/QrCode.jsx
@@ -26,9 +26,7 @@ const ComponentToPrint = forwardRef(({ style, url, queueName }, ref) => {
   );
 });
 
-const QrCode = (props) => {
-  const { queueName, show, onClose } = props;
-
+export const QrCode = ({ queueName, handleModalClose }) => {
   const componentPrintRef = useRef();
 
   const handlePrint = useReactToPrint({
@@ -53,28 +51,43 @@ const QrCode = (props) => {
     };
   })();
 
-  const handleModalClose = () => onClose(false);
+  const CloseButton = ({ handleModalCloseHandler }) => {
+    if (handleModalCloseHandler) {
+      return (
+        <StandardButton onClick={handleModalCloseHandler} icon={<HighlightOffIcon />} outlined>
+          Close
+        </StandardButton>
+      );
+    }
+    return <></>;
+  };
 
   return (
-    <Modal open={queueName ? show : !show} onClose={handleModalClose}>
-      <div className={styles['centered']}>
-        <ComponentToPrint
-          style={styles['centered']}
-          url={`${window.location.origin}/j/${queueName}`}
-          queueName={queueName}
-          ref={componentPrintRef}
-        />
-        <div className={styles['actionContainer']}>
-          <StandardButton onClick={handlePrint} icon={<PrintIcon />}>
-            Print
-          </StandardButton>
-          <StandardButton onClick={handleModalClose} icon={<HighlightOffIcon />} outlined>
-            Close
-          </StandardButton>
-        </div>
+    <div className={styles['centered']}>
+      <ComponentToPrint
+        style={styles['centered']}
+        url={`${window.location.origin}/j/${queueName}`}
+        queueName={queueName}
+        ref={componentPrintRef}
+      />
+      <div className={styles['actionContainer']}>
+        <StandardButton onClick={handlePrint} icon={<PrintIcon />}>
+          Print
+        </StandardButton>
+        <CloseButton handleModalCloseHandler={handleModalClose} />
       </div>
+    </div>
+  );
+};
+
+const QrCodeModal = (props) => {
+  const { queueName, show, onClose } = props;
+  const handleModalClose = () => onClose(false);
+  return (
+    <Modal open={queueName ? show : !show} onClose={handleModalClose}>
+      <QrCode queueName={queueName} handleModalClose={handleModalClose} />
     </Modal>
   );
 };
 
-export default QrCode;
+export default QrCodeModal;

--- a/simplq/src/components/common/Popup/QrCode.jsx
+++ b/simplq/src/components/common/Popup/QrCode.jsx
@@ -14,7 +14,7 @@ const ComponentToPrint = forwardRef(({ style, url, queueName }, ref) => {
       <h1>
         <u>{getSentenceCaseText(queueName)}</u>
       </h1>
-      <h2>Scan this QR to begin!</h2>
+      <h2>Scan this QR to get your position in the line</h2>
       <QRCode value={url} />
       <p style={{ textAlign: 'center' }}>
         {'or visit '}

--- a/simplq/src/components/pages/Admin/AdminHeaderSection.jsx
+++ b/simplq/src/components/pages/Admin/AdminHeaderSection.jsx
@@ -11,7 +11,7 @@ import ShareQueue from './ShareQueue';
 import styles from './admin.module.scss';
 
 const HeaderSection = ({ description, queueName, queueId }) => {
-  const [showQrCodeModal, setShowQrCodeModal] = useState(false);
+  const [showQrCodeModal, setShowQrCodeModal] = useState(true);
   const dispatch = useDispatch();
   const getSelectedQueue = useGetSelectedQueue();
 
@@ -33,7 +33,7 @@ const HeaderSection = ({ description, queueName, queueId }) => {
       </div>
       <div className={styles['main-button-group']}>
         <div className={styles['admin-button']}>
-          <StandardButton onClick={generateQrCOde} icon={<CropFreeIcon />} outlined>
+          <StandardButton onClick={generateQrCOde} icon={<CropFreeIcon />}>
             Generate QR Code
           </StandardButton>
           {showQrCodeModal && (
@@ -41,12 +41,12 @@ const HeaderSection = ({ description, queueName, queueId }) => {
           )}
         </div>
         <div className={styles['admin-button']}>
+          <ShareQueue tourTag="reactour__shareQueue" queueName={queueName} />
+        </div>
+        <div className={styles['admin-button']}>
           <StandardButton onClick={handleRefreshClick} icon={<RefreshIcon />} outlined>
             Refresh status
           </StandardButton>
-        </div>
-        <div className={styles['admin-button']}>
-          <ShareQueue tourTag="reactour__shareQueue" queueName={queueName} />
         </div>
       </div>
     </div>

--- a/simplq/src/components/pages/Admin/AdminHeaderSection.jsx
+++ b/simplq/src/components/pages/Admin/AdminHeaderSection.jsx
@@ -11,7 +11,7 @@ import ShareQueue from './ShareQueue';
 import styles from './admin.module.scss';
 
 const HeaderSection = ({ description, queueName, queueId }) => {
-  const [showQrCodeModal, setShowQrCodeModal] = useState(true);
+  const [showQrCodeModal, setShowQrCodeModal] = useState(false);
   const dispatch = useDispatch();
   const getSelectedQueue = useGetSelectedQueue();
 

--- a/simplq/src/components/pages/Admin/AdminPage.jsx
+++ b/simplq/src/components/pages/Admin/AdminPage.jsx
@@ -56,7 +56,7 @@ export default (props) => {
         />
       )}
       <div className={styles['main-body']}>
-        <TokenList queueId={queueId} />
+        <TokenList queueName={queueName} queueId={queueId} />
         <SidePanel queueId={queueId} />
       </div>
     </div>

--- a/simplq/src/components/pages/Admin/AdminSidePanel.jsx
+++ b/simplq/src/components/pages/Admin/AdminSidePanel.jsx
@@ -2,17 +2,13 @@ import React from 'react';
 import SidePanel from 'components/common/SidePanel';
 import QueueDetails from './QueueInfo';
 import AddMember from './AddMember';
-import PauseQueue from './PauseQueue';
 import DeleteQueue from './DeleteQueue';
-import QueueHistory from './QueueHistory';
 import QueueSettings from './QueueSettings';
 
 export default ({ queueId }) => (
   <SidePanel>
     <AddMember queueId={queueId} />
-    <PauseQueue queueId={queueId} />
     <DeleteQueue queueId={queueId} />
-    <QueueHistory />
     <QueueDetails queueId={queueId} />
     <QueueSettings queueId={queueId} />
   </SidePanel>

--- a/simplq/src/components/pages/Admin/TokenList.jsx
+++ b/simplq/src/components/pages/Admin/TokenList.jsx
@@ -2,14 +2,27 @@ import React from 'react';
 import Loading from 'components/common/Loading/Loading';
 import { useSelector } from 'react-redux';
 import { selectTokens } from 'store/selectedQueue';
+import { QrCode } from 'components/common/Popup/QrCode';
 import Token from './Token';
 import styles from './admin.module.scss';
 
-function TokenList() {
+const EmptyTokenList = ({ queueName }) => {
+  return (
+    <>
+      <p>
+        Your queue has been created and is currently empty. Add people to he queue and share the
+        below QR code for them to see their status
+      </p>
+      <QrCode queueName={queueName} />
+    </>
+  );
+};
+
+const TokenList = ({ queueName }) => {
   const tokens = useSelector(selectTokens);
   const ListContent = () =>
     tokens.length === 0 ? (
-      <p>Your queue has been created and is currently empty. Waiting for people to join...</p>
+      <EmptyTokenList queueName={queueName} />
     ) : (
       tokens.map((token) => <Token token={token} key={token.tokenId} />)
     );
@@ -21,6 +34,6 @@ function TokenList() {
       </div>
     </Loading>
   );
-}
+};
 
 export default TokenList;

--- a/simplq/src/components/pages/Admin/TokenList.jsx
+++ b/simplq/src/components/pages/Admin/TokenList.jsx
@@ -10,7 +10,7 @@ const EmptyTokenList = ({ queueName }) => {
   return (
     <>
       <p>
-        Your queue has been created and is currently empty. Add people to he queue and share the
+        Your line has been created and is currently empty. Add people to the line and share the
         below QR code for them to see their status
       </p>
       <QrCode queueName={queueName} />

--- a/simplq/src/components/pages/TokenStatus/TokenSidePanel.jsx
+++ b/simplq/src/components/pages/TokenStatus/TokenSidePanel.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import SidePanel from 'components/common/SidePanel';
-import LeaveQueue from './LeaveQueue';
 import ContactAdmin from './ContactAdmin';
 import QueueDetails from './QueueInfo';
 import NotificationContainer from './NotificationContainer';
 
 export default () => (
   <SidePanel>
-    <LeaveQueue />
     <ContactAdmin />
     <QueueDetails />
     <NotificationContainer />

--- a/simplq/src/components/pages/TokenStatus/TokenSidePanel.jsx
+++ b/simplq/src/components/pages/TokenStatus/TokenSidePanel.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import SidePanel from 'components/common/SidePanel';
-import ContactAdmin from './ContactAdmin';
 import QueueDetails from './QueueInfo';
 import NotificationContainer from './NotificationContainer';
 
 export default () => (
   <SidePanel>
-    <ContactAdmin />
     <QueueDetails />
     <NotificationContainer />
   </SidePanel>


### PR DESCRIPTION
Added the QR code to be displayed on the admin page if the queue is empty. The modal is set to open on page refresh, so it'll show up once the queue is created for the first time.

![Screenshot from 2021-04-24 18-05-44](https://user-images.githubusercontent.com/12583528/115959025-b8f05d80-a527-11eb-9420-321f0f7fb76e.png)
