### PR TITLE
Replace history on trying to join invalid queue

### DIFF
--- a/simplq/src/store/asyncActions/getQueueInfoByName.js
+++ b/simplq/src/store/asyncActions/getQueueInfoByName.js
@@ -23,7 +23,7 @@ const useGetQueueInfoByName = () => {
         const response = await authedRequest;
         return response;
       } catch (error) {
-        history.push(`/pageNotFound/queueName=${queueName}`);
+        history.replace(`/pageNotFound/queueName=${queueName}`);
         return rejectWithValue({ message: `Queue ${queueName} does not exist, try again...` });
       }
     }


### PR DESCRIPTION
Fixes #610. I came across history.replace() while reading an article, didn't know it existed. I haven't noticed any side-effects while testing, so we should be good with this.