### PR TITLE
Release 7th August 2021

### DIFF
--- a/simplq/public/index.html
+++ b/simplq/public/index.html
@@ -58,6 +58,7 @@
     -->
     <title>SimplQ</title>
     <script async defer src="https://buttons.github.io/buttons.js"></script>
+    <!-- Uncomment for typeform chat auto-pop up. TODO: Enable on bigger screens only 
     <script>
       if (!localStorage.getItem('chat-shown')) {
         setTimeout(() => {
@@ -65,7 +66,7 @@
           localStorage.setItem('chat-shown', true);
         }, 10000);
       }
-    </script>
+    </script>-->
   </head>
 
   <body>

--- a/simplq/public/index.html
+++ b/simplq/public/index.html
@@ -58,10 +58,25 @@
     -->
     <title>SimplQ</title>
     <script async defer src="https://buttons.github.io/buttons.js"></script>
+    <script>
+      if (!localStorage.getItem('chat-shown')) {
+        setTimeout(() => {
+          document.getElementById('chat-typeform').click();
+          localStorage.setItem('chat-shown', true);
+        }, 10000);
+      }
+    </script>
   </head>
 
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div
+      id="chat-typeform"
+      data-tf-popover="PPh4SmaA"
+      data-tf-chat
+      data-tf-button-color="#0445AF"
+    ></div>
+    <script src="//embed.typeform.com/next/embed.js"></script>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/simplq/src/components/common/Popup/QrCode.jsx
+++ b/simplq/src/components/common/Popup/QrCode.jsx
@@ -26,7 +26,7 @@ const ComponentToPrint = forwardRef(({ style, url, queueName }, ref) => {
   );
 });
 
-export const QrCode = ({ queueName, handleModalClose }) => {
+export const QrCode = ({ queueName, tourTag, handleModalClose }) => {
   const componentPrintRef = useRef();
 
   const handlePrint = useReactToPrint({
@@ -70,7 +70,10 @@ export const QrCode = ({ queueName, handleModalClose }) => {
         queueName={queueName}
         ref={componentPrintRef}
       />
-      <div className={styles['actionContainer']}>
+      <div
+        reactour-selector={tourTag}
+        className={handleModalClose ? styles['actionContainer'] : null}
+      >
         <StandardButton onClick={handlePrint} icon={<PrintIcon />}>
           Print
         </StandardButton>

--- a/simplq/src/components/common/Tour/Tour.jsx
+++ b/simplq/src/components/common/Tour/Tour.jsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
 import Tour from 'reactour';
-import * as Sentry from '@sentry/react';
+import DoneIcon from '@material-ui/icons/DoneRounded';
+import ArrowBackRoundedIcon from '@material-ui/icons/ArrowBackRounded';
+import ArrowForwardRoundedIcon from '@material-ui/icons/ArrowForwardRounded';
 import { enableScroll, disableScroll } from './ControlScroll';
+import styles from './Tour.module.scss';
 
 export default (props) => {
   const hasUserBeenOnTour = () => {
@@ -13,28 +16,23 @@ export default (props) => {
     return false;
   };
   const [tourOpen, setTourOpen] = useState(hasUserBeenOnTour());
+  const [stepNumber, setStepNumber] = useState(0);
 
   const closeTour = () => setTourOpen(false);
 
-  const stepChange = (stepNumber) => {
-    const leftArrow = document.querySelector("[data-tour-elem='left-arrow']");
-    const rightArrow = document.querySelector("[data-tour-elem='right-arrow']");
-
-    if (leftArrow && rightArrow) {
-      if (stepNumber === 0) {
-        leftArrow.childNodes[0].style.color = 'grey';
-        rightArrow.childNodes[0].style.color = 'white';
-      } else if (stepNumber === props.toursteps.length - 1) {
-        leftArrow.childNodes[0].style.color = 'white';
-        rightArrow.childNodes[0].style.color = 'grey';
-      }
-    } else {
-      Sentry.captureMessage('left-arrow or right-arrow selectors of reatTour package not found');
-    }
+  const stepChange = (step) => {
+    setStepNumber(step);
   };
+
+  const PrevNavButton = (
+    <ArrowBackRoundedIcon
+      className={stepNumber ? styles['nav-button'] : styles['disabled-nav-button']}
+    />
+  );
 
   return (
     <Tour
+      className={styles['tour-box']}
       showNavigation={false}
       steps={props.toursteps}
       showNavigationNumber={false}
@@ -46,6 +44,9 @@ export default (props) => {
       onAfterOpen={disableScroll}
       onBeforeClose={enableScroll}
       getCurrentStep={stepChange}
+      prevButton={PrevNavButton}
+      nextButton={<ArrowForwardRoundedIcon className={styles['nav-button']} />}
+      lastStepNextButton={<DoneIcon className={styles['nav-button']} />}
     />
   );
 };

--- a/simplq/src/components/common/Tour/Tour.module.scss
+++ b/simplq/src/components/common/Tour/Tour.module.scss
@@ -1,0 +1,15 @@
+@import 'components/common.scss';
+
+.tour-box {
+  button {
+    margin: 0 0.625rem 0 0;
+  }
+}
+
+.nav-button {
+  color: #fff;
+}
+
+.disabled-nav-button {
+  color: #999999;
+}

--- a/simplq/src/components/pages/Admin/AdminPage.jsx
+++ b/simplq/src/components/pages/Admin/AdminPage.jsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { selectQueueName } from 'store/selectedQueue';
 import Ribbon from 'components/common/Ribbon';
 import Tour from 'components/common/Tour';
-import { useGetSelectedQueue, useGetQueueInfo } from 'store/asyncActions';
+import { useGetSelectedQueue } from 'store/asyncActions';
 import { selectQueueInfo } from 'store/queueInfo';
 import { setErrorPopupMessage } from 'store/appSlice';
 import { useHistory } from 'react-router';
@@ -26,18 +26,11 @@ const AdminPage = (props) => {
   const queueInfo = useSelector(selectQueueInfo);
   const dispatch = useDispatch();
   const history = useHistory();
-  const getQueueInfo = useCallback(useGetQueueInfo(), []);
 
-  useEffect(() => {
-    dispatch(getQueueInfo({ queueId }));
-  }, [dispatch, queueId, getQueueInfo]);
-
-  useEffect(() => {
-    if (queueInfo && queueId === queueInfo?.queueId && isQueueDeleted(queueInfo)) {
-      dispatch(setErrorPopupMessage('This queue is deleted.'));
-      history.push('/');
-    }
-  }, [dispatch, history, queueId, queueInfo]);
+  if (queueInfo && queueId === queueInfo?.queueId && isQueueDeleted(queueInfo)) {
+    dispatch(setErrorPopupMessage('This queue is deleted.'));
+    history.push('/');
+  }
 
   return <AdminPageView queueId={queueId} />;
 };

--- a/simplq/src/components/pages/Admin/AdminPage.jsx
+++ b/simplq/src/components/pages/Admin/AdminPage.jsx
@@ -6,7 +6,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { selectQueueName } from 'store/selectedQueue';
 import Ribbon from 'components/common/Ribbon';
 import Tour from 'components/common/Tour';
-import { useGetSelectedQueue } from 'store/asyncActions';
+import { useGetSelectedQueue, useGetQueueInfo } from 'store/asyncActions';
+import { selectQueueInfo } from 'store/queueInfo';
+import { setErrorPopupMessage } from 'store/appSlice';
+import { useHistory } from 'react-router';
 import HeaderSection from './AdminHeaderSection';
 import TokenList from './TokenList';
 import styles from './admin.module.scss';
@@ -16,8 +19,31 @@ import getToursteps from './getTourSteps';
 const TIMEOUT = 10000;
 let timeoutId;
 
-export default (props) => {
+const isQueueDeleted = (queueInfo) => queueInfo?.status === 'DELETED';
+
+const AdminPage = (props) => {
   const queueId = props.match.params.queueId;
+  const queueInfo = useSelector(selectQueueInfo);
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const getQueueInfo = useCallback(useGetQueueInfo(), []);
+
+  useEffect(() => {
+    dispatch(getQueueInfo({ queueId }));
+  }, [dispatch, queueId, getQueueInfo]);
+
+  useEffect(() => {
+    if (queueInfo && queueId === queueInfo?.queueId && isQueueDeleted(queueInfo)) {
+      dispatch(setErrorPopupMessage('This queue is deleted.'));
+      history.push('/');
+    }
+  }, [dispatch, history, queueId, queueInfo]);
+
+  return <AdminPageView queueId={queueId} />;
+};
+
+const AdminPageView = (props) => {
+  const { queueId } = props;
   const queueName = useSelector(selectQueueName);
   const description = queueName && 'Ready to share';
   const dispatch = useDispatch();
@@ -62,3 +88,5 @@ export default (props) => {
     </div>
   );
 };
+
+export default AdminPage;

--- a/simplq/src/components/pages/Admin/QueueSettings.module.scss
+++ b/simplq/src/components/pages/Admin/QueueSettings.module.scss
@@ -14,7 +14,44 @@
   margin-bottom: 1.5rem;
 }
 
+.self-join-checkbox {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 1.5rem;
+}
+
 .action-container {
   display: flex;
   justify-content: space-evenly;
+}
+
+.self-join-input {
+  -webkit-appearance: none;
+  background-color: inherit;
+  border: 0.5px solid #cacece;
+  border-radius: 3px;
+  display: inline-block;
+  margin: 0;
+  padding: 9px;
+  position: relative;
+}
+
+.self-join-input:checked {
+  background-color: $primary-color-dark;
+}
+
+.self-join-input:hover {
+  cursor: pointer;
+}
+
+.self-join-label {
+  margin-left: 0.5rem;
+}
+
+.checkbox-label-unchecked {
+  opacity: 0.5;
+}
+
+.checkbox-label-checked {
+  color: $primary-color-dark;
 }

--- a/simplq/src/components/pages/Admin/TokenList.jsx
+++ b/simplq/src/components/pages/Admin/TokenList.jsx
@@ -13,7 +13,7 @@ const EmptyTokenList = ({ queueName }) => {
         Your line has been created and is currently empty. Add people to the line and share the
         below QR code for them to see their status
       </p>
-      <QrCode queueName={queueName} />
+      <QrCode tourTag="reactour__printQRCode" queueName={queueName} />
     </>
   );
 };

--- a/simplq/src/components/pages/Admin/getTourSteps.jsx
+++ b/simplq/src/components/pages/Admin/getTourSteps.jsx
@@ -60,6 +60,31 @@ const getToursteps = (screenInnerWidth) => {
       },
       position: 'top',
     },
+    {
+      selector: '[reactour-selector="reactour__printQRCode"]',
+      content: () => (
+        <>
+          {tourProperties.isArrowVisible ? (
+            <img
+              src="/images/sharequeueArrow.png"
+              alt="share queue arrow"
+              height="80"
+              width="120"
+              style={{ transform: 'rotate(-10deg)' }}
+            />
+          ) : null}
+          <div style={{ transform: 'rotate(-10deg)' }}>Print QR Code</div>
+        </>
+      ),
+      style: {
+        fontFamily: 'Pacifico',
+        backgroundColor: 'transparent',
+        color: 'white',
+        fontSize: '1.563rem',
+        boxShadow: 'none',
+      },
+      position: 'left',
+    },
   ];
 };
 export default getToursteps;

--- a/simplq/src/store/asyncActions/getQueueInfoByName.js
+++ b/simplq/src/store/asyncActions/getQueueInfoByName.js
@@ -23,7 +23,7 @@ const useGetQueueInfoByName = () => {
         const response = await authedRequest;
         return response;
       } catch (error) {
-        history.push(`/pageNotFound/queueName=${queueName}`);
+        history.replace(`/pageNotFound/queueName=${queueName}`);
         return rejectWithValue({ message: `Queue ${queueName} does not exist, try again...` });
       }
     }

--- a/simplq/src/store/queueInfo/queueInfoSlice.js
+++ b/simplq/src/store/queueInfo/queueInfoSlice.js
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { getQueueInfo, getQueueInfoByName } from 'store/asyncActions';
+import { deleteQueue, getQueueInfo, getQueueInfoByName } from 'store/asyncActions';
 
 const queueInfoSlice = createSlice({
   name: 'queueInfo',
@@ -12,6 +12,16 @@ const queueInfoSlice = createSlice({
     },
     [getQueueInfoByName.fulfilled]: (state, action) => {
       return action.payload;
+    },
+    [deleteQueue.fulfilled]: (state, action) => {
+      const { queueId } = action.payload;
+      if (state.queueId === queueId) {
+        return {
+          ...state,
+          status: 'DELETED',
+        };
+      }
+      return state;
     },
   },
 });

--- a/simplq/src/store/selectedQueue/index.js
+++ b/simplq/src/store/selectedQueue/index.js
@@ -7,4 +7,5 @@ export {
   selectTokens,
   selectQueueStatus,
   selectMaxQueueCapacity,
+  selectIsSelfJoinAllowed,
 } from './selectedQueueSlice';

--- a/simplq/src/store/selectedQueue/selectedQueueSlice.js
+++ b/simplq/src/store/selectedQueue/selectedQueueSlice.js
@@ -38,6 +38,7 @@ const selectedQueueSlice = createSlice({
     // update queue settings
     [updateQueueSettings.fulfilled]: (state, action) => {
       state.maxQueueCapacity = action.payload.maxQueueCapacity;
+      state.isSelfJoinAllowed = action.payload.isSelfJoinAllowed;
       return state;
     },
   },
@@ -52,3 +53,5 @@ export const selectTokens = (state) => state.selectedQueue.tokens;
 export const selectQueueStatus = (state) => state.selectedQueue.status;
 
 export const selectMaxQueueCapacity = (state) => state.selectedQueue.maxQueueCapacity;
+
+export const selectIsSelfJoinAllowed = (state) => state.selectedQueue.selfJoinAllowed;


### PR DESCRIPTION
Noteworthy change in this release is that we have a checkbox to enable auto-join.

Auto-join if enabled will let people join on their own after scanning the QR code. Default behaviour  (the checkbox is unticked by default) is to let users only see their token status on the queue link by entering their mobile number to access the token status page.

There are minor other bugfixes and improvements that went in, see individual commits for more information.