### PR TITLE
Changes in UI of dialogue box in QueueSettings and copy queue link menu

### DIFF
--- a/simplq/src/components/pages/Admin/QueueSettings.jsx
+++ b/simplq/src/components/pages/Admin/QueueSettings.jsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import SettingsIcon from '@material-ui/icons/Settings';
-import Modal from 'components/common/Modal';
+import { Dialog, Grid } from '@material-ui/core';
 import HighlightOffIcon from '@material-ui/icons/HighlightOff';
 import SidePanelItem from 'components/common/SidePanel/SidePanelItem';
 import { useUpdateQueueSettings } from 'store/asyncActions';
 import { useDispatch, useSelector } from 'react-redux';
-import Grid from '@material-ui/core/Grid';
 import SaveIcon from '@material-ui/icons/Save';
 import { selectMaxQueueCapacity, selectIsSelfJoinAllowed } from 'store/selectedQueue';
 import Button from 'components/common/Button';
@@ -64,7 +63,7 @@ export default ({ queueId }) => {
   return (
     <>
       <SidePanelItem Icon={SettingsIcon} title="Queue Settings" onClick={toggleModal} />
-      <Modal open={isModalOpen}>
+      <Dialog PaperProps={{ style: { width: '27%', borderRadius: 30 } }} open={isModalOpen}>
         <Grid container className={styles['modal-content']} direction="column">
           <h2 className={styles['title']}>Settings</h2>
           <InputField
@@ -88,7 +87,7 @@ export default ({ queueId }) => {
             </Button>
           </div>
         </Grid>
-      </Modal>
+      </Dialog>
     </>
   );
 };

--- a/simplq/src/components/pages/Admin/ShareQueue.jsx
+++ b/simplq/src/components/pages/Admin/ShareQueue.jsx
@@ -11,6 +11,8 @@ import {
   Button,
   Grow,
   MenuItem,
+  Divider,
+  Typography,
 } from '@material-ui/core';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import {
@@ -97,7 +99,10 @@ const ShareQueue = ({ queueName, tourTag }) => {
             <Paper>
               <ClickAwayListener onClickAway={handleClose}>
                 <MenuList>
-                  Share
+                  <Typography>
+                    <b>Share</b>
+                  </Typography>
+                  <Divider />
                   <MenuItem>
                     <FacebookShareButton
                       url={link}
@@ -105,15 +110,17 @@ const ShareQueue = ({ queueName, tourTag }) => {
                       className={styles['share-button']}
                     >
                       <FacebookIcon size={24} round className={styles['share-icon']} />
-                      Facebook
+                      <Typography>Facebook</Typography>
                     </FacebookShareButton>
                   </MenuItem>
+                  <Divider />
                   <MenuItem>
                     <TwitterShareButton url={link} title={quote} className={styles['share-button']}>
                       <TwitterIcon size={24} round className={styles['share-icon']} />
-                      Twitter
+                      <Typography>Twitter</Typography>
                     </TwitterShareButton>
                   </MenuItem>
+                  <Divider />
                   <MenuItem>
                     <WhatsappShareButton
                       url={link}
@@ -121,7 +128,7 @@ const ShareQueue = ({ queueName, tourTag }) => {
                       className={styles['share-button']}
                     >
                       <WhatsappIcon size={24} round className={styles['share-icon']} />
-                      Whatsapp
+                      <Typography>Whatsapp</Typography>
                     </WhatsappShareButton>
                   </MenuItem>
                 </MenuList>


### PR DESCRIPTION
Hey,
I have made some UI changes in the dialogue box which appears when clicked on the queuesetting button
Previously when clicked on the QueueSettings button it just appears instantly which was not looking that good but now it appears with a small transition effect (fadeIn and fadeout) which is giving a smooth opening and looks nice
and 
I have also implemented a divider in the menu which opens from a side button of the Copy Queue button,
previously It appears a little too plane and now due to dividers it looks nice and separated,
Please have a look 
Thank you