### PR TITLE
Show last removed token number

### DIFF
--- a/simplq/src/components/common/QueueInfo/QueueInfo.jsx
+++ b/simplq/src/components/common/QueueInfo/QueueInfo.jsx
@@ -35,6 +35,7 @@ export default ({ queueId }) => {
     numberOfActiveTokens,
     totalNumberOfTokens,
     maxQueueCapacity,
+    lastRemovedTokenNumber,
   } = useSelector(selectQueueInfo);
 
   const availableSlots = maxQueueCapacity - numberOfActiveTokens;
@@ -50,6 +51,7 @@ export default ({ queueId }) => {
     <div className={styles['detail']}>
       <DetailRow title="Queue status:" value={status} />
       <DetailRow title="Available Slots:" value={availableSlots} large valueId="slots-value" />
+      <DetailRow title="Last token number that was called:" value={lastRemovedTokenNumber} />
       <DetailRow title="People currently in queue:" value={numberOfActiveTokens} large />
       <DetailRow title="Total number of people joined in queue:" value={totalNumberOfTokens} />
       <DetailRow title="Queue creation time:" value={creationTime} />


### PR DESCRIPTION
@sajmalyousef was asking if we can show the last token number that was removed from the queue:

Waiting Time:
![image](https://user-images.githubusercontent.com/11256376/135841730-d5bae6f4-2ae6-4994-bdac-2d6f75c14f12.png)


Join Time:
![image](https://user-images.githubusercontent.com/11256376/135841455-80be442f-f63c-4cb7-bb5d-003178c21eb5.png)
