### PR TITLE
[FIX] queue history footer using flex-wrap

### DIFF
--- a/simplq/src/components/pages/Admin/QueueHistoryPanel.jsx
+++ b/simplq/src/components/pages/Admin/QueueHistoryPanel.jsx
@@ -5,6 +5,7 @@ import QueueHistory from 'components/common/QueueHistory/QueueHistory';
 import TablePagination from '@material-ui/core/TablePagination';
 import { useSelector } from 'react-redux';
 import { selectQueueHistoryEvents } from 'store/selectedQueueHistory';
+import styles from './QueueHistoryPanel.module.scss';
 
 export default (props) => {
   const [page, setPage] = React.useState(0);
@@ -34,6 +35,7 @@ export default (props) => {
       />
       <div>
         <TablePagination
+          className={styles['tablePaginationContainer']}
           component="div"
           rowsPerPageOptions={[5, 10, 25, 50, 100]}
           count={Data.length}

--- a/simplq/src/components/pages/Admin/QueueHistoryPanel.module.scss
+++ b/simplq/src/components/pages/Admin/QueueHistoryPanel.module.scss
@@ -1,0 +1,9 @@
+@import 'components/common.scss';
+
+.tablePaginationContainer {
+  > div {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
Fix issue #659 

scroll-x removed and flex-wrap applied to container. Also, it was created an scss file to isolate the styling of this component
![Captura de tela de 2021-10-04 21-16-10](https://user-images.githubusercontent.com/55103977/135941427-6b374115-1ea4-4a24-b8c3-8e90e81bead7.png)

