### PR TITLE
chore(deps): bump prettier deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "simplQ-frontend",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  },
+  "dependencies": {
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "prettier": "^2.7.1"
+  }
+}


### PR DESCRIPTION
Hi!

The aim of this PR is to contribute to **Hacktoberfest 2022** and to bump prettier dependency to its latest stable version (2.7.1) improving the performance of the package itself. 

Cheers!

<img src="https://media.giphy.com/media/BPJmthQ3YRwD6QqcVD/giphy-downsized.gif" />